### PR TITLE
Fix auth refresh, broken imports, and add OAuth token flow

### DIFF
--- a/custom_components/samsung_familyhub_fridge/camera.py
+++ b/custom_components/samsung_familyhub_fridge/camera.py
@@ -1,29 +1,10 @@
-from urllib.parse import urlencode
-
-import requests
-
-from homeassistant.components.camera import PLATFORM_SCHEMA, Camera
-from homeassistant.components.local_file.camera import LocalFile
+from homeassistant.components.camera import Camera
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import HTTP_DIGEST_AUTHENTICATION
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.update_coordinator import (
-    CoordinatorEntity,
-    DataUpdateCoordinator,
-    UpdateFailed,
-)
-from homeassistant.core import callback
+
 from .const import DOMAIN
-from .api import FamilyHub, DataCoordinator
-from homeassistant.components.update import (
-    UpdateDeviceClass,
-    UpdateEntity,
-    UpdateEntityFeature,
-)
-from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
-from .sensor import LastUpdatedAt
+from .api import FamilyHub
 
 
 async def async_setup_entry(
@@ -31,22 +12,8 @@ async def async_setup_entry(
     config_entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    # def setup_platform(
-    #     hass: HomeAssistant,
-    #     config: ConfigType,
-    #     add_entities: AddEntitiesCallback,
-    #     discovery_info: DiscoveryInfoType | None = None,
-    # ) -> None:
-    """Set up the Axis camera video stream."""
+    """Set up the Samsung Family Hub fridge cameras."""
     hub = hass.data[DOMAIN]["hub"]
-    # platform = entity_platform.async_get_current_platform()
-
-    # This will call Entity.set_sleep_timer(sleep_time=VALUE)
-    # platform.async_register_entity_service(
-    #     "refresh",
-    #     {},
-    #     "refresh",
-    # )
     async_add_entities(
         [
             FamilyHubCamera("family_hub_top", 0, hub),

--- a/custom_components/samsung_familyhub_fridge/sensor.py
+++ b/custom_components/samsung_familyhub_fridge/sensor.py
@@ -1,25 +1,11 @@
-from urllib.parse import urlencode
-
-import requests
-
-from homeassistant.components.camera import PLATFORM_SCHEMA, Camera
-from homeassistant.components.local_file.camera import LocalFile
+from homeassistant.components.sensor import SensorEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import HTTP_DIGEST_AUTHENTICATION
-from homeassistant.core import HomeAssistant
-from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from homeassistant.core import callback
 from .const import DOMAIN
-from .api import FamilyHub, DataCoordinator
-
-from homeassistant.components.sensor import PLATFORM_SCHEMA, SensorEntity
-from homeassistant.helpers.update_coordinator import (
-    CoordinatorEntity,
-    DataUpdateCoordinator,
-    UpdateFailed,
-)
+from .api import DataCoordinator
 
 
 async def async_setup_entry(


### PR DESCRIPTION
## Summary

- Fix broken imports in `camera.py` and `sensor.py` that prevent the integration from loading on modern HA versions (`LocalFile`, `HTTP_DIGEST_AUTHENTICATION` removed)
- Detect expired SmartThings tokens (401/403) and trigger HA's built-in re-authentication UI instead of silently failing
- Add defensive error handling for missing API response keys (`items`, `samsungce.viewInside`, `contactSensor`) that caused KeyError crashes
- Remove deprecated `async_timeout` usage
- Add OAuth 2.0 token flow with PKCE and headless Samsung Account login for sustainable token management
- Add 52 unit tests and 16 integration tests

Fixes #14, #2, #5, #7

## Test plan
- [x] 52 unit tests pass (auth detection, KeyError handling, token update, coordinator propagation, OAuth, Samsung login)
- [x] 16 integration tests skip gracefully without credentials
- [ ] Pull updated integration into HA instance and verify it loads without ImportError
- [ ] Verify reauth flow triggers when token expires

https://claude.ai/code/session_01D5qFc3fxKn6A431aRieGVG