### PR TITLE
Add manual refresh service and trigger refresh on startup

### DIFF
--- a/custom_components/samsung_familyhub_fridge/__init__.py
+++ b/custom_components/samsung_familyhub_fridge/__init__.py
@@ -1,12 +1,16 @@
 """The Samsung FamilyHub Fridge integration."""
 from __future__ import annotations
 
+import logging
+
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, ServiceCall
 
 from .api import FamilyHub
 from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
 
 PLATFORMS: list[Platform] = [Platform.CAMERA, Platform.SENSOR]
 
@@ -25,6 +29,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
+    async def _handle_refresh(call: ServiceCall) -> None:
+        """Manually trigger a fridge camera refresh."""
+        _LOGGER.info("Manual refresh requested — sending update_camera command")
+        await hass.async_add_executor_job(hub.update_camera)
+        # Also flag the coordinator to pick up new images on next poll
+        hub.should_update = False  # already sent the command
+        _LOGGER.info("Manual refresh command sent successfully")
+
+    hass.services.async_register(DOMAIN, "refresh", _handle_refresh)
+
     return True
 
 
@@ -38,5 +52,6 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
     if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
         hass.data[DOMAIN].pop(entry.entry_id)
+        hass.services.async_remove(DOMAIN, "refresh")
 
     return unload_ok

--- a/custom_components/samsung_familyhub_fridge/api.py
+++ b/custom_components/samsung_familyhub_fridge/api.py
@@ -36,14 +36,21 @@ class DataCoordinator(DataUpdateCoordinator):
         """Fetch data from API endpoint."""
         try:
             if self.api.device_id is None:
+                _LOGGER.debug("No device_id — fetching device list")
                 status = await self._hass.async_add_executor_job(
                     self.api.get_all_device_status
                 )
                 self.api.set_device_status(status)
             if self.api.should_update:
+                _LOGGER.debug("should_update=True → sending refresh command to fridge")
                 await self._hass.async_add_executor_job(self.api.update_camera)
                 self.api.should_update = False
             elif set(self.last_file_ids) != set(self.api.get_file_ids()):
+                _LOGGER.debug(
+                    "file IDs changed: %s → %s, downloading images",
+                    self.last_file_ids,
+                    self.api.get_file_ids(),
+                )
                 await self._hass.async_add_executor_job(self.api.download_images)
                 self.last_updated_at = time.time()
                 self.last_file_ids = self.api.get_file_ids()
@@ -53,6 +60,12 @@ class DataCoordinator(DataUpdateCoordinator):
                 )
                 self.api.set_current_device_status(status)
                 self.api.extract_device_data()
+                _LOGGER.debug(
+                    "polled status: last_closed=%s should_update=%s file_ids=%s",
+                    self.api.last_closed,
+                    self.api.should_update,
+                    self.api.get_file_ids(),
+                )
         except AuthenticationError as err:
             raise ConfigEntryAuthFailed(
                 "SmartThings token expired or is invalid. "
@@ -174,9 +187,22 @@ class FamilyHub:
                 "contactSensor data not available in device status"
             )
             return
-        if contact["value"] == "closed" and contact["timestamp"] != self.last_closed:
+        _LOGGER.debug(
+            "contactSensor: value=%s timestamp=%s (last_closed=%s)",
+            contact.get("value"),
+            contact.get("timestamp"),
+            self.last_closed,
+        )
+        # Trigger a refresh on first poll after startup, so users see fresh
+        # images without having to physically open and close the fridge door.
+        first_poll = self.last_closed is None
+        if contact["value"] == "closed" and (
+            first_poll or contact["timestamp"] != self.last_closed
+        ):
             self.last_closed = contact["timestamp"]
             self.should_update = True
+            if first_poll:
+                _LOGGER.debug("First poll after startup — requesting camera refresh")
 
     def get_file_ids(self):
         """Get the file IDs for the camera images."""

--- a/custom_components/samsung_familyhub_fridge/camera.py
+++ b/custom_components/samsung_familyhub_fridge/camera.py
@@ -1,29 +1,10 @@
-from urllib.parse import urlencode
-
-import requests
-
-from homeassistant.components.camera import PLATFORM_SCHEMA, Camera
-from homeassistant.components.local_file.camera import LocalFile
+from homeassistant.components.camera import Camera
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import HTTP_DIGEST_AUTHENTICATION
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.update_coordinator import (
-    CoordinatorEntity,
-    DataUpdateCoordinator,
-    UpdateFailed,
-)
-from homeassistant.core import callback
+
 from .const import DOMAIN
-from .api import FamilyHub, DataCoordinator
-from homeassistant.components.update import (
-    UpdateDeviceClass,
-    UpdateEntity,
-    UpdateEntityFeature,
-)
-from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
-from .sensor import LastUpdatedAt
+from .api import FamilyHub
 
 
 async def async_setup_entry(
@@ -31,22 +12,8 @@ async def async_setup_entry(
     config_entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    # def setup_platform(
-    #     hass: HomeAssistant,
-    #     config: ConfigType,
-    #     add_entities: AddEntitiesCallback,
-    #     discovery_info: DiscoveryInfoType | None = None,
-    # ) -> None:
-    """Set up the Axis camera video stream."""
+    """Set up the Samsung Family Hub fridge cameras."""
     hub = hass.data[DOMAIN]["hub"]
-    # platform = entity_platform.async_get_current_platform()
-
-    # This will call Entity.set_sleep_timer(sleep_time=VALUE)
-    # platform.async_register_entity_service(
-    #     "refresh",
-    #     {},
-    #     "refresh",
-    # )
     async_add_entities(
         [
             FamilyHubCamera("family_hub_top", 0, hub),

--- a/custom_components/samsung_familyhub_fridge/sensor.py
+++ b/custom_components/samsung_familyhub_fridge/sensor.py
@@ -1,25 +1,11 @@
-from urllib.parse import urlencode
-
-import requests
-
-from homeassistant.components.camera import PLATFORM_SCHEMA, Camera
-from homeassistant.components.local_file.camera import LocalFile
+from homeassistant.components.sensor import SensorEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import HTTP_DIGEST_AUTHENTICATION
-from homeassistant.core import HomeAssistant
-from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from homeassistant.core import callback
 from .const import DOMAIN
-from .api import FamilyHub, DataCoordinator
-
-from homeassistant.components.sensor import PLATFORM_SCHEMA, SensorEntity
-from homeassistant.helpers.update_coordinator import (
-    CoordinatorEntity,
-    DataUpdateCoordinator,
-    UpdateFailed,
-)
+from .api import DataCoordinator
 
 
 async def async_setup_entry(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -159,11 +159,28 @@ def _make_module(name, **attrs):
 # --- Stub out homeassistant and its subpackages ---
 
 
+class _ServiceRegistry:
+    def __init__(self):
+        self._services = {}
+
+    def async_register(self, domain, service, handler):
+        self._services[(domain, service)] = handler
+
+    def async_remove(self, domain, service):
+        self._services.pop((domain, service), None)
+
+
+class _ServiceCall:
+    def __init__(self, data=None):
+        self.data = data or {}
+
+
 class _HomeAssistant:
     """Minimal stub of homeassistant.core.HomeAssistant."""
 
     def __init__(self):
         self.async_add_executor_job = AsyncMock(side_effect=self._run_sync)
+        self.services = _ServiceRegistry()
 
     async def _run_sync(self, func, *args):
         return func(*args)
@@ -236,7 +253,12 @@ class _Platform:
 
 # Build fake module tree
 ha = _make_module("homeassistant")
-ha_core = _make_module("homeassistant.core", HomeAssistant=_HomeAssistant, callback=lambda f: f)
+ha_core = _make_module(
+    "homeassistant.core",
+    HomeAssistant=_HomeAssistant,
+    ServiceCall=_ServiceCall,
+    callback=lambda f: f,
+)
 ha_config_entries = _make_module(
     "homeassistant.config_entries",
     ConfigEntry=_ConfigEntry,


### PR DESCRIPTION
## Summary

- `extract_device_data()` now triggers a refresh on first poll after startup so users see fresh images without manually opening/closing the fridge
- New service `samsung_familyhub_fridge.refresh` to manually trigger the camera refresh API
- Debug logging throughout the coordinator for easier troubleshooting

## Test plan
- [x] 52 unit tests pass
- [ ] Deploy to HA, verify images refresh on restart
- [ ] Call `samsung_familyhub_fridge.refresh` service and verify it works

https://claude.ai/code/session_01D5qFc3fxKn6A431aRieGVG