### PR TITLE
feat(auth): reuse HA core SmartThings OAuth credentials (auto-refresh, fixes 24h PAT expiry)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ __pycache__/
 *.pyc
 .pytest_cache/
 .smartthings_credentials.json
+.venv/

--- a/custom_components/samsung_familyhub_fridge/__init__.py
+++ b/custom_components/samsung_familyhub_fridge/__init__.py
@@ -1,14 +1,42 @@
-"""The Samsung FamilyHub Fridge integration."""
+"""The Samsung FamilyHub Fridge integration.
+
+Auth modes (data["auth_mode"]):
+
+- "oauth"  : Reuse the HA core `smartthings` integration's OAuth2 credentials.
+             Tokens refresh automatically via HA's OAuth2Session — no manual
+             PAT rotation. Requires a working `smartthings` config entry
+             referenced by `data["linked_smartthings_entry_id"]`.
+
+- "pat"    : Legacy SmartThings Personal Access Token (raw string). Samsung
+             deprecated indefinite PATs on 2024-12-30 — new PATs expire after
+             24 hours. Retained for backwards compatibility only.
+
+Config entries created before this integration version stored `{token, device_id}`
+without an `auth_mode` key; they are migrated to `auth_mode: "pat"` on first
+load via `async_migrate_entry`.
+"""
 from __future__ import annotations
 
 import logging
+from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.helpers import config_entry_oauth2_flow
 
 from .api import FamilyHub
-from .const import DOMAIN
+from .const import (
+    AUTH_MODE_OAUTH,
+    AUTH_MODE_PAT,
+    CONF_AUTH_MODE,
+    CONF_DEVICE_ID,
+    CONF_LINKED_SMARTTHINGS_ENTRY_ID,
+    CONF_TOKEN,
+    DOMAIN,
+    SMARTTHINGS_DOMAIN,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -19,9 +47,21 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Samsung FamilyHub Fridge from a config entry."""
     hass.data.setdefault(DOMAIN, {})
 
-    hub = FamilyHub(
-        hass, entry.data["token"], entry.data.get("device_id")
-    )
+    auth_mode = entry.data.get(CONF_AUTH_MODE, AUTH_MODE_PAT)
+    device_id = entry.data.get(CONF_DEVICE_ID)
+
+    if auth_mode == AUTH_MODE_OAUTH:
+        hub = await _build_oauth_hub(hass, entry, device_id)
+    else:
+        # Legacy PAT path — unchanged from v0.0.x.
+        token = entry.data.get(CONF_TOKEN)
+        if not token:
+            raise ConfigEntryNotReady(
+                "PAT-mode config entry has no token. Reconfigure the "
+                "integration in Settings → Devices & Services."
+            )
+        hub = FamilyHub(hass, token=token, device_id=device_id)
+
     hass.data[DOMAIN][entry.entry_id] = entry
     hass.data[DOMAIN]["hub"] = hub
 
@@ -32,8 +72,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     async def _handle_refresh(call: ServiceCall) -> None:
         """Manually trigger a fridge camera refresh."""
         _LOGGER.info("Manual refresh requested — sending update_camera command")
+        await hub.async_ensure_fresh_token()
         await hass.async_add_executor_job(hub.update_camera)
-        # Also flag the coordinator to pick up new images on next poll
         hub.should_update = False  # already sent the command
         _LOGGER.info("Manual refresh command sent successfully")
 
@@ -42,16 +82,85 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return True
 
 
+async def _build_oauth_hub(
+    hass: HomeAssistant, entry: ConfigEntry, device_id: str | None
+) -> FamilyHub:
+    """Construct a FamilyHub that borrows the HA core smartthings OAuth session.
+
+    Raises ConfigEntryNotReady if the linked smartthings entry is missing or
+    not loaded yet — HA will retry the setup automatically.
+    """
+    linked_id = entry.data.get(CONF_LINKED_SMARTTHINGS_ENTRY_ID)
+    if not linked_id:
+        raise ConfigEntryNotReady(
+            "OAuth-mode entry missing linked_smartthings_entry_id — "
+            "reconfigure to re-link the HA core SmartThings integration."
+        )
+
+    smartthings_entry = hass.config_entries.async_get_entry(linked_id)
+    if smartthings_entry is None or smartthings_entry.domain != SMARTTHINGS_DOMAIN:
+        raise ConfigEntryNotReady(
+            f"Linked SmartThings entry {linked_id} not found. "
+            "Re-add the HA core SmartThings integration and reconfigure this one."
+        )
+
+    impl = await config_entry_oauth2_flow.async_get_config_entry_implementation(
+        hass, smartthings_entry
+    )
+    session = config_entry_oauth2_flow.OAuth2Session(hass, smartthings_entry, impl)
+
+    try:
+        await session.async_ensure_token_valid()
+    except Exception as err:  # pylint: disable=broad-except
+        # OAuth2Session wraps errors in aiohttp/client exceptions. The SmartThings
+        # entry itself will handle reauth — we just need to back off here.
+        raise ConfigEntryNotReady(
+            f"Failed to obtain a fresh SmartThings OAuth token: {err}"
+        ) from err
+
+    token = session.token["access_token"]
+    hub = FamilyHub(hass, token=token, device_id=device_id)
+    hub.attach_oauth_session(session)
+    return hub
+
+
 async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """Handle config entry updates (e.g. after re-authentication)."""
     hub: FamilyHub = hass.data[DOMAIN]["hub"]
-    hub.update_token(entry.data["token"])
+    auth_mode = entry.data.get(CONF_AUTH_MODE, AUTH_MODE_PAT)
+    if auth_mode == AUTH_MODE_PAT:
+        new_token = entry.data.get(CONF_TOKEN)
+        if new_token:
+            hub.update_token(new_token)
+    # OAuth mode refreshes its token automatically — nothing to do here.
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
     if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
-        hass.data[DOMAIN].pop(entry.entry_id)
-        hass.services.async_remove(DOMAIN, "refresh")
+        hass.data[DOMAIN].pop(entry.entry_id, None)
+        hass.data[DOMAIN].pop("hub", None)
+        # Only deregister the service when no other entries remain
+        if not [
+            eid for eid in hass.data[DOMAIN] if eid != "hub"
+        ]:
+            hass.services.async_remove(DOMAIN, "refresh")
 
     return unload_ok
+
+
+async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Migrate config entry data to the current schema.
+
+    v1  → {token, device_id}                     (raw PAT)
+    v2  → adds auth_mode=(pat|oauth), optional linked_smartthings_entry_id
+    """
+    if entry.version == 1:
+        new_data: dict[str, Any] = {**entry.data, CONF_AUTH_MODE: AUTH_MODE_PAT}
+        hass.config_entries.async_update_entry(entry, data=new_data, version=2)
+        _LOGGER.info(
+            "Migrated samsung_familyhub_fridge entry %s v1→v2 (auth_mode=pat). "
+            "Reconfigure in UI to switch to OAuth.",
+            entry.entry_id,
+        )
+    return True

--- a/custom_components/samsung_familyhub_fridge/api.py
+++ b/custom_components/samsung_familyhub_fridge/api.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 from datetime import timedelta
 import logging
 import time
+from typing import TYPE_CHECKING
+
 from homeassistant.helpers.update_coordinator import (
     DataUpdateCoordinator,
 )
@@ -11,6 +13,9 @@ import requests
 from homeassistant.core import HomeAssistant
 
 from .const import CID, DEFAULT_TIMEOUT
+
+if TYPE_CHECKING:
+    from homeassistant.helpers import config_entry_oauth2_flow
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -35,6 +40,9 @@ class DataCoordinator(DataUpdateCoordinator):
     async def _async_update_data(self):
         """Fetch data from API endpoint."""
         try:
+            # OAuth mode: refresh the access token (if close to expiry) BEFORE
+            # any API call. No-op for PAT mode.
+            await self.api.async_ensure_fresh_token()
             if self.api.device_id is None:
                 _LOGGER.debug("No device_id — fetching device list")
                 status = await self._hass.async_add_executor_job(
@@ -83,7 +91,20 @@ class DataCoordinator(DataUpdateCoordinator):
 
 
 class FamilyHub:
-    """SmartThings Family Hub fridge API client."""
+    """SmartThings Family Hub fridge API client.
+
+    Two auth modes:
+
+    1. PAT mode (default): caller provides a raw SmartThings token via
+       `token=`. Token is static; caller is responsible for refresh via
+       `update_token()`.
+
+    2. OAuth mode: after construction, caller attaches an
+       ``OAuth2Session`` via `attach_oauth_session(session)`. Before every
+       API call the coordinator awaits `async_ensure_fresh_token()` which
+       asks HA's OAuth2Session to refresh the access token if it's close
+       to expiry — no manual refresh needed.
+    """
 
     def __init__(self, hass: HomeAssistant, token: str, device_id: str) -> None:
         """Initialize."""
@@ -97,9 +118,34 @@ class FamilyHub:
         self.last_closed = None
         self.should_update = False
         self.downloaded_images = [None, None, None]
+        self._oauth_session: "config_entry_oauth2_flow.OAuth2Session | None" = None
+
+    def attach_oauth_session(
+        self, session: "config_entry_oauth2_flow.OAuth2Session"
+    ) -> None:
+        """Bind an HA OAuth2Session so tokens refresh automatically.
+
+        Once attached, `async_ensure_fresh_token()` consults this session
+        before every API call and updates the bearer header in place.
+        """
+        self._oauth_session = session
+
+    async def async_ensure_fresh_token(self) -> None:
+        """If running in OAuth mode, ensure the bearer token is still valid.
+
+        No-op for PAT mode. Safe to call on every poll — HA's OAuth2Session
+        only performs a network refresh when the access_token is within
+        a few seconds of expiring.
+        """
+        if self._oauth_session is None:
+            return
+        await self._oauth_session.async_ensure_token_valid()
+        new_token = self._oauth_session.token.get("access_token")
+        if new_token and new_token != self.token:
+            self.update_token(new_token)
 
     def update_token(self, token: str) -> None:
-        """Update the API token (used after re-authentication)."""
+        """Update the API token (used after re-authentication or OAuth refresh)."""
         self.token = token
         self._headers = {"Authorization": f"Bearer {self.token}"}
 

--- a/custom_components/samsung_familyhub_fridge/config_flow.py
+++ b/custom_components/samsung_familyhub_fridge/config_flow.py
@@ -10,24 +10,34 @@ from homeassistant import config_entries
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import config_entry_oauth2_flow
 
 from .api import AuthenticationError, FamilyHub
-from .const import DOMAIN
+from .const import (
+    AUTH_MODE_OAUTH,
+    AUTH_MODE_PAT,
+    CONF_AUTH_MODE,
+    CONF_DEVICE_ID,
+    CONF_LINKED_SMARTTHINGS_ENTRY_ID,
+    CONF_TOKEN,
+    DOMAIN,
+    SMARTTHINGS_DOMAIN,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
 
-STEP_USER_DATA_SCHEMA = vol.Schema(
+STEP_PAT_DATA_SCHEMA = vol.Schema(
     {
-        vol.Required("token"): str,
-        vol.Optional("device_id"): str,
+        vol.Required(CONF_TOKEN): str,
+        vol.Optional(CONF_DEVICE_ID): str,
     }
 )
 
 
-async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str, Any]:
-    """Validate the user input allows us to connect."""
-    hub = FamilyHub(hass, data["token"], data.get("device_id"))
+async def _validate_pat(hass: HomeAssistant, data: dict[str, Any]) -> dict[str, Any]:
+    """Validate a Personal Access Token and resolve the device ID."""
+    hub = FamilyHub(hass, data[CONF_TOKEN], data.get(CONF_DEVICE_ID))
 
     try:
         if not await hub.authenticate():
@@ -35,25 +45,126 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str,
     except AuthenticationError as err:
         raise InvalidAuth from err
 
-    if not data.get("device_id"):
-        data["device_id"] = hub.device_id
+    if not data.get(CONF_DEVICE_ID):
+        data[CONF_DEVICE_ID] = hub.device_id
 
     return data
+
+
+async def _validate_oauth(
+    hass: HomeAssistant, smartthings_entry_id: str, device_id: str | None
+) -> dict[str, Any]:
+    """Validate that we can borrow the SmartThings OAuth session, probe the fridge."""
+    smartthings_entry = hass.config_entries.async_get_entry(smartthings_entry_id)
+    if smartthings_entry is None or smartthings_entry.domain != SMARTTHINGS_DOMAIN:
+        raise CannotConnect(
+            f"Linked SmartThings entry {smartthings_entry_id} not found"
+        )
+
+    impl = await config_entry_oauth2_flow.async_get_config_entry_implementation(
+        hass, smartthings_entry
+    )
+    session = config_entry_oauth2_flow.OAuth2Session(hass, smartthings_entry, impl)
+    try:
+        await session.async_ensure_token_valid()
+    except Exception as err:  # pylint: disable=broad-except
+        raise InvalidAuth from err
+
+    token = session.token["access_token"]
+    hub = FamilyHub(hass, token=token, device_id=device_id)
+    hub.attach_oauth_session(session)
+
+    try:
+        if not await hub.authenticate():
+            raise InvalidAuth
+    except AuthenticationError as err:
+        raise InvalidAuth from err
+
+    return {
+        CONF_AUTH_MODE: AUTH_MODE_OAUTH,
+        CONF_LINKED_SMARTTHINGS_ENTRY_ID: smartthings_entry_id,
+        CONF_DEVICE_ID: device_id or hub.device_id,
+    }
+
+
+def _smartthings_entries(hass: HomeAssistant) -> list[config_entries.ConfigEntry]:
+    """Return all loaded HA core smartthings config entries."""
+    return [
+        e
+        for e in hass.config_entries.async_entries(SMARTTHINGS_DOMAIN)
+        if e.source != config_entries.SOURCE_IGNORE
+    ]
 
 
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Samsung FamilyHub Fridge."""
 
-    VERSION = 1
+    VERSION = 2
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
-        """Handle the initial step."""
+        """First step — offer OAuth reuse if a smartthings entry exists."""
+        if _smartthings_entries(self.hass):
+            return self.async_show_menu(
+                step_id="user",
+                menu_options=["oauth", "pat"],
+            )
+        # No HA core smartthings entry → force PAT path
+        return await self.async_step_pat()
+
+    # ---------------- OAuth path ----------------
+
+    async def async_step_oauth(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Offer to reuse an existing HA core SmartThings OAuth entry."""
+        entries = _smartthings_entries(self.hass)
+        if not entries:
+            return await self.async_step_pat()
+
+        errors: dict[str, str] = {}
+        options = {e.entry_id: e.title or e.entry_id for e in entries}
+
+        if user_input is not None:
+            try:
+                data = await _validate_oauth(
+                    self.hass,
+                    user_input[CONF_LINKED_SMARTTHINGS_ENTRY_ID],
+                    user_input.get(CONF_DEVICE_ID) or None,
+                )
+            except CannotConnect:
+                errors["base"] = "cannot_connect"
+            except InvalidAuth:
+                errors["base"] = "invalid_auth"
+            except Exception:  # pylint: disable=broad-except
+                _LOGGER.exception("Unexpected exception during OAuth validation")
+                errors["base"] = "unknown"
+            else:
+                return self.async_create_entry(
+                    title="Samsung Fridge Camera (OAuth)", data=data
+                )
+
+        schema = vol.Schema(
+            {
+                vol.Required(CONF_LINKED_SMARTTHINGS_ENTRY_ID): vol.In(options),
+                vol.Optional(CONF_DEVICE_ID): str,
+            }
+        )
+        return self.async_show_form(
+            step_id="oauth", data_schema=schema, errors=errors
+        )
+
+    # ---------------- PAT path (legacy) ----------------
+
+    async def async_step_pat(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Enter a raw SmartThings Personal Access Token (legacy, 24h expiry)."""
         errors: dict[str, str] = {}
         if user_input is not None:
             try:
-                info = await validate_input(self.hass, user_input)
+                info = await _validate_pat(self.hass, user_input)
             except CannotConnect:
                 errors["base"] = "cannot_connect"
             except InvalidAuth:
@@ -62,28 +173,43 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 _LOGGER.exception("Unexpected exception")
                 errors["base"] = "unknown"
             else:
-                return self.async_create_entry(title="Samsung Fridge Camera", data=info)
+                data = {**info, CONF_AUTH_MODE: AUTH_MODE_PAT}
+                return self.async_create_entry(
+                    title="Samsung Fridge Camera", data=data
+                )
 
         return self.async_show_form(
-            step_id="user", data_schema=STEP_USER_DATA_SCHEMA, errors=errors
+            step_id="pat", data_schema=STEP_PAT_DATA_SCHEMA, errors=errors
         )
+
+    # ---------------- Reauth ----------------
 
     async def async_step_reauth(
         self, entry_data: dict[str, Any]
     ) -> FlowResult:
         """Handle re-authentication when the token has expired."""
+        # OAuth-mode entries should never reach reauth: HA's OAuth2Session
+        # refreshes transparently and any hard failure is surfaced on the
+        # linked smartthings entry itself. If we do land here, offer both
+        # paths again so the user can re-link.
+        if entry_data.get(CONF_AUTH_MODE) == AUTH_MODE_OAUTH:
+            return await self.async_step_user()
         return await self.async_step_reauth_confirm()
 
     async def async_step_reauth_confirm(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
-        """Handle user input for re-authentication."""
+        """Handle PAT re-authentication."""
         errors: dict[str, str] = {}
         if user_input is not None:
             reauth_entry = self._get_reauth_entry()
-            new_data = {**reauth_entry.data, "token": user_input["token"]}
+            new_data = {
+                **reauth_entry.data,
+                CONF_TOKEN: user_input[CONF_TOKEN],
+                CONF_AUTH_MODE: AUTH_MODE_PAT,
+            }
             try:
-                await validate_input(self.hass, new_data)
+                await _validate_pat(self.hass, new_data)
             except InvalidAuth:
                 errors["base"] = "invalid_auth"
             except Exception:  # pylint: disable=broad-except
@@ -96,7 +222,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         return self.async_show_form(
             step_id="reauth_confirm",
-            data_schema=vol.Schema({vol.Required("token"): str}),
+            data_schema=vol.Schema({vol.Required(CONF_TOKEN): str}),
             errors=errors,
         )
 

--- a/custom_components/samsung_familyhub_fridge/const.py
+++ b/custom_components/samsung_familyhub_fridge/const.py
@@ -3,3 +3,16 @@
 DOMAIN = "samsung_familyhub_fridge"
 CID = "5Hic3rk1FP"
 DEFAULT_TIMEOUT = 10
+
+# Config entry `data` keys
+CONF_AUTH_MODE = "auth_mode"
+CONF_TOKEN = "token"
+CONF_DEVICE_ID = "device_id"
+CONF_LINKED_SMARTTHINGS_ENTRY_ID = "linked_smartthings_entry_id"
+
+# Auth mode values
+AUTH_MODE_OAUTH = "oauth"   # reuse HA core smartthings OAuth2 credentials
+AUTH_MODE_PAT = "pat"       # legacy: raw SmartThings Personal Access Token
+
+# Domain of the HA core SmartThings integration we piggyback on
+SMARTTHINGS_DOMAIN = "smartthings"

--- a/custom_components/samsung_familyhub_fridge/manifest.json
+++ b/custom_components/samsung_familyhub_fridge/manifest.json
@@ -1,12 +1,14 @@
 {
   "domain": "samsung_familyhub_fridge",
   "name": "Samsung FamilyHub Fridge",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "codeowners": [
-    "@ibielopolskyi"
+    "@ibielopolskyi",
+    "@nachtschatt3n"
   ],
   "config_flow": true,
   "dependencies": [],
+  "after_dependencies": ["smartthings"],
   "documentation": "https://github.com/ibielopolskyi/smartthings_fridge_camera",
   "integration_type": "hub",
   "homekit": {},

--- a/custom_components/samsung_familyhub_fridge/strings.json
+++ b/custom_components/samsung_familyhub_fridge/strings.json
@@ -2,9 +2,27 @@
   "config": {
     "step": {
       "user": {
+        "title": "Choose authentication method",
+        "description": "Samsung deprecated indefinite SmartThings Personal Access Tokens on 2024-12-30 — new PATs expire every 24 hours. Reusing the HA core SmartThings integration's OAuth2 credentials avoids this limit entirely.",
+        "menu_options": {
+          "oauth": "Reuse HA core SmartThings OAuth (recommended)",
+          "pat": "Enter a Personal Access Token (legacy)"
+        }
+      },
+      "oauth": {
+        "title": "Reuse SmartThings OAuth credentials",
+        "description": "Select an existing HA core SmartThings integration to borrow its OAuth2 credentials. Tokens will refresh automatically.",
+        "data": {
+          "linked_smartthings_entry_id": "SmartThings integration",
+          "device_id": "Device ID (optional)"
+        }
+      },
+      "pat": {
+        "title": "SmartThings Personal Access Token",
+        "description": "Tokens created after 2024-12-30 expire every 24 hours. You will need to reauthenticate after each expiry.",
         "data": {
           "token": "SmartThings Token",
-          "device_id": "Device ID"
+          "device_id": "Device ID (optional)"
         }
       },
       "reauth_confirm": {

--- a/custom_components/samsung_familyhub_fridge/translations/en.json
+++ b/custom_components/samsung_familyhub_fridge/translations/en.json
@@ -11,9 +11,27 @@
         },
         "step": {
             "user": {
+                "title": "Choose authentication method",
+                "description": "Samsung deprecated indefinite SmartThings Personal Access Tokens on 2024-12-30 — new PATs expire every 24 hours. Reusing the HA core SmartThings integration's OAuth2 credentials avoids this limit entirely.",
+                "menu_options": {
+                    "oauth": "Reuse HA core SmartThings OAuth (recommended)",
+                    "pat": "Enter a Personal Access Token (legacy)"
+                }
+            },
+            "oauth": {
+                "title": "Reuse SmartThings OAuth credentials",
+                "description": "Select an existing HA core SmartThings integration to borrow its OAuth2 credentials. Tokens will refresh automatically.",
                 "data": {
-                    "device_id": "Device ID",
-                    "token": "SmartThings Token"
+                    "linked_smartthings_entry_id": "SmartThings integration",
+                    "device_id": "Device ID (optional)"
+                }
+            },
+            "pat": {
+                "title": "SmartThings Personal Access Token",
+                "description": "Tokens created after 2024-12-30 expire every 24 hours. You will need to reauthenticate after each expiry.",
+                "data": {
+                    "token": "SmartThings Token",
+                    "device_id": "Device ID (optional)"
                 }
             },
             "reauth_confirm": {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -269,9 +269,14 @@ ha_const = _make_module(
     Platform=_Platform,
     HTTP_DIGEST_AUTHENTICATION="digest",
 )
+class _ConfigEntryNotReady(Exception):
+    """Stub: HA raises this to defer entry setup."""
+
+
 ha_exceptions = _make_module(
     "homeassistant.exceptions",
     ConfigEntryAuthFailed=_ConfigEntryAuthFailed,
+    ConfigEntryNotReady=_ConfigEntryNotReady,
     HomeAssistantError=_HomeAssistantError,
 )
 ha_data_entry_flow = _make_module(
@@ -299,6 +304,44 @@ ha_helpers_typing = _make_module(
     "homeassistant.helpers.typing",
     ConfigType=dict,
     DiscoveryInfoType=dict,
+)
+
+
+class _OAuth2SessionStub:
+    """Minimal OAuth2Session used by tests.
+
+    Tracks a single `token` dict and a counter of refresh calls so tests
+    can assert the integration calls `async_ensure_token_valid()` before
+    each API hit.
+    """
+
+    def __init__(self, hass, entry, impl) -> None:
+        self.hass = hass
+        self.config_entry = entry
+        self.implementation = impl
+        self.token = {"access_token": "oauth-token-initial"}
+        self.ensure_calls = 0
+        self._next_refresh_value = None
+
+    async def async_ensure_token_valid(self):
+        self.ensure_calls += 1
+        if self._next_refresh_value is not None:
+            self.token = {"access_token": self._next_refresh_value}
+            self._next_refresh_value = None
+
+    def queue_refresh(self, new_access_token: str) -> None:
+        """Arrange for the next `ensure` call to rotate the token."""
+        self._next_refresh_value = new_access_token
+
+
+async def _async_get_config_entry_implementation_stub(hass, entry):
+    return MagicMock()
+
+
+ha_helpers_oauth2 = _make_module(
+    "homeassistant.helpers.config_entry_oauth2_flow",
+    OAuth2Session=_OAuth2SessionStub,
+    async_get_config_entry_implementation=_async_get_config_entry_implementation_stub,
 )
 
 # components tree
@@ -338,6 +381,7 @@ _modules = {
     "homeassistant.helpers.entity_platform": ha_helpers_entity_platform,
     "homeassistant.helpers.dispatcher": ha_helpers_dispatcher,
     "homeassistant.helpers.typing": ha_helpers_typing,
+    "homeassistant.helpers.config_entry_oauth2_flow": ha_helpers_oauth2,
     "homeassistant.components": ha_components,
     "homeassistant.components.camera": ha_components_camera,
     "homeassistant.components.local_file": ha_components_local_file,

--- a/tests/test_oauth_reuse.py
+++ b/tests/test_oauth_reuse.py
@@ -1,0 +1,129 @@
+"""Unit tests for the OAuth-reuse auth path.
+
+Covers:
+- FamilyHub.attach_oauth_session / async_ensure_fresh_token
+- FamilyHub transparently picks up a rotated access_token from the session
+- DataCoordinator._async_update_data calls async_ensure_fresh_token before
+  each cycle (via the hub)
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+import requests_mock as rm
+
+# conftest installs HA stubs before any component imports
+from tests.conftest import (
+    _HomeAssistant,
+    _OAuth2SessionStub,
+)
+
+from custom_components.samsung_familyhub_fridge.api import (
+    DataCoordinator,
+    FamilyHub,
+)
+
+
+@pytest.fixture
+def hass():
+    return _HomeAssistant()
+
+
+@pytest.fixture
+def session():
+    return _OAuth2SessionStub(hass=None, entry=None, impl=None)
+
+
+@pytest.fixture
+def hub_oauth(hass, session):
+    # Initial token is passed at construction (what the plumbing does after
+    # first async_ensure_token_valid in __init__.py), then the session is
+    # attached so subsequent refreshes are automatic.
+    hub = FamilyHub(hass, token="oauth-token-initial", device_id="device-123")
+    hub.attach_oauth_session(session)
+    return hub
+
+
+# ---------------------------------------------------------------------------
+# FamilyHub.async_ensure_fresh_token
+# ---------------------------------------------------------------------------
+
+async def test_async_ensure_fresh_token_noop_for_pat(hass):
+    """PAT-mode hubs never call the OAuth session."""
+    hub = FamilyHub(hass, token="pat-token", device_id="d")
+    # No session attached → call should return quietly and leave token alone
+    await hub.async_ensure_fresh_token()
+    assert hub.token == "pat-token"
+
+
+async def test_async_ensure_fresh_token_calls_session(hub_oauth, session):
+    """OAuth-mode hubs defer refresh to the attached session each call."""
+    assert session.ensure_calls == 0
+    await hub_oauth.async_ensure_fresh_token()
+    assert session.ensure_calls == 1
+    await hub_oauth.async_ensure_fresh_token()
+    assert session.ensure_calls == 2
+
+
+async def test_async_ensure_fresh_token_rotates_bearer(hub_oauth, session):
+    """When the session rotates the access_token, the bearer header updates."""
+    assert hub_oauth.token == "oauth-token-initial"
+    assert hub_oauth._headers["Authorization"] == "Bearer oauth-token-initial"
+
+    # Arrange for the next ensure-call to return a fresh token
+    session.queue_refresh("oauth-token-rotated")
+    await hub_oauth.async_ensure_fresh_token()
+
+    assert hub_oauth.token == "oauth-token-rotated"
+    assert hub_oauth._headers["Authorization"] == "Bearer oauth-token-rotated"
+
+
+async def test_async_ensure_fresh_token_idempotent_when_unchanged(hub_oauth, session):
+    """If the session's token is unchanged, the header is not rewritten needlessly."""
+    original_headers = hub_oauth._headers
+    await hub_oauth.async_ensure_fresh_token()
+    # Same object identity — update_token was never called
+    assert hub_oauth._headers is original_headers
+
+
+# ---------------------------------------------------------------------------
+# DataCoordinator integration
+# ---------------------------------------------------------------------------
+
+async def test_coordinator_refreshes_token_before_each_poll(hub_oauth, session, hass):
+    """Coordinator awaits the hub's fresh-token helper before any API call."""
+    coordinator = DataCoordinator(hass, hub_oauth)
+
+    # Make the underlying sync methods pure no-ops for this test
+    hub_oauth.get_current_device_status = MagicMock(return_value={})
+    hub_oauth.set_current_device_status = MagicMock()
+    hub_oauth.extract_device_data = MagicMock()
+    hub_oauth.get_file_ids = MagicMock(return_value=[])
+
+    session.queue_refresh("rotated-1")
+    await coordinator._async_update_data()
+    assert session.ensure_calls == 1
+    assert hub_oauth.token == "rotated-1"
+
+    session.queue_refresh("rotated-2")
+    await coordinator._async_update_data()
+    assert session.ensure_calls == 2
+    assert hub_oauth.token == "rotated-2"
+
+
+async def test_coordinator_noop_ensure_for_pat(hass, requests_mock):
+    """PAT-mode coordinator skips the OAuth refresh path entirely."""
+    hub = FamilyHub(hass, token="pat-token", device_id="device-123")
+    coordinator = DataCoordinator(hass, hub)
+
+    hub.get_current_device_status = MagicMock(return_value={})
+    hub.set_current_device_status = MagicMock()
+    hub.extract_device_data = MagicMock()
+    hub.get_file_ids = MagicMock(return_value=[])
+
+    # Must complete without any OAuth session attached
+    await coordinator._async_update_data()
+    # Token is unchanged
+    assert hub.token == "pat-token"


### PR DESCRIPTION
## Summary

Samsung [deprecated indefinite SmartThings Personal Access Tokens on 2024-12-30](https://community.smartthings.com/t/old-personal-access-token-stopped-working-after-the-expiration-change/293450) — new PATs now expire every 24 hours. For users who restart Home Assistant more often than that, the current integration becomes unusable because it has no refresh flow.

This PR lets the integration **reuse the OAuth2 credentials already managed by Home Assistant core's `smartthings` integration**, so access tokens refresh automatically via HA's built-in `OAuth2Session` framework. No more manual PAT dance.

The legacy PAT path is preserved unchanged — existing users keep working after upgrade; they can switch to OAuth whenever they're ready.

## How it works

1. `config_flow.py` detects existing HA core `smartthings` config entries and offers a menu: **"Reuse HA core SmartThings OAuth"** (new, recommended) or **"Enter a Personal Access Token"** (legacy).
2. When OAuth is chosen, the selected `smartthings` entry's `entry_id` is stored as `linked_smartthings_entry_id`. No new OAuth client registration needed.
3. `__init__.py` looks up the linked entry, builds an `OAuth2Session` via `config_entry_oauth2_flow.async_get_config_entry_implementation`, ensures a fresh token on first setup, and passes it to `FamilyHub` via the new `attach_oauth_session()` method.
4. `api.py`'s `DataCoordinator._async_update_data` awaits `hub.async_ensure_fresh_token()` at the top of every cycle — HA's `OAuth2Session.async_ensure_token_valid()` is cheap when the token is still valid and transparently refreshes it when close to expiry. The hub updates its bearer header with the new access_token.
5. `async_migrate_entry` bumps existing entries from schema v1 → v2, tagging them as `auth_mode: pat` so they keep working identically.

## Changes

| File | Change |
|---|---|
| `manifest.json` | version `0.1.0`, `after_dependencies: [smartthings]`, add me as codeowner for fork maintenance |
| `const.py` | new `AUTH_MODE_OAUTH`/`AUTH_MODE_PAT`, `CONF_LINKED_SMARTTHINGS_ENTRY_ID`, `SMARTTHINGS_DOMAIN` |
| `__init__.py` | branch on `auth_mode`; build `OAuth2Session` for oauth mode; `async_migrate_entry` v1→v2 |
| `api.py` | `FamilyHub.attach_oauth_session()`, `async_ensure_fresh_token()`. Coordinator awaits the helper before each update. No-op for PAT. |
| `config_flow.py` | `VERSION = 2`. New menu-driven `async_step_user` → `async_step_oauth` / `async_step_pat`. Legacy reauth unchanged. |
| `strings.json` + `translations/en.json` | new step labels/descriptions |
| `tests/conftest.py` | stubs for `ConfigEntryNotReady` and `config_entry_oauth2_flow` with a queueable fake `OAuth2Session` |
| `tests/test_oauth_reuse.py` | 6 new tests covering refresh propagation, PAT no-op, coordinator integration |

## Tests

All **58 tests pass** (52 existing + 6 new):

```
tests/test_auth_refresh.py ...........................  [ 46%]
tests/test_oauth.py .........................           [ 89%]
tests/test_oauth_reuse.py ......                        [100%]
========================= 58 passed in 0.10s ===========================
```

## Fixes

- #14 Camera Feed Stops Updating After a Few Days — OAuth auto-refresh eliminates the 24h expiry window
- #15 Error After Rebooting Hass.io – ditto

## Backwards compatibility

- Existing `{token, device_id}` config entries migrate in place (via `async_migrate_entry`). Users who don't switch modes see no change.
- If no HA core `smartthings` entry exists, the flow skips the menu and goes straight to the legacy PAT form.
- `FamilyHub(token=..., device_id=...)` signature unchanged; OAuth session is **optional** via `attach_oauth_session()`.

## Test plan for reviewers

- [ ] Fresh install (no HA core smartthings entry) → PAT flow works identically to v0.0.1
- [ ] Fresh install with HA core smartthings entry configured → menu appears, OAuth path creates entry with `auth_mode: oauth`
- [ ] Existing v1 entry → auto-migrates to v2 `auth_mode: pat`; no user-visible change
- [ ] OAuth entry survives 48h uptime (two SmartThings token cycles) with no auth errors

---

Happy to iterate on review — particularly on the config_flow UX (menu placement, labels) and whether you want the OAuth path to be the default when a smartthings entry exists.