### PR TITLE
Add Accept header for public API file download

### DIFF
--- a/custom_components/samsung_familyhub_fridge/api.py
+++ b/custom_components/samsung_familyhub_fridge/api.py
@@ -218,9 +218,12 @@ class FamilyHub:
                         f"https://client.smartthings.com/udo/file_links/"
                         f"{file_id}?cid={CID}&di={self.device_id}"
                     )
+                req_headers = {**self._headers}
+                if self._oauth_session is not None:
+                    req_headers["Accept"] = "*/*"
                 r = requests.get(
                     url,
-                    headers=self._headers,
+                    headers=req_headers,
                     timeout=DEFAULT_TIMEOUT,
                 )
                 self._check_response(r)


### PR DESCRIPTION
The /v1/devices/{id}/files/{fileId} endpoint returns 406 Not Acceptable without an Accept header.

https://claude.ai/code/session_01D5qFc3fxKn6A431aRieGVG