### PR TITLE
Fix Accept header for file download endpoint

### DIFF
--- a/custom_components/samsung_familyhub_fridge/api.py
+++ b/custom_components/samsung_familyhub_fridge/api.py
@@ -220,7 +220,7 @@ class FamilyHub:
                     )
                 req_headers = {**self._headers}
                 if self._oauth_session is not None:
-                    req_headers["Accept"] = "*/*"
+                    req_headers["Accept"] = "application/octet-stream, image/jpeg, image/*, */*"
                 r = requests.get(
                     url,
                     headers=req_headers,


### PR DESCRIPTION
Use explicit content types (application/octet-stream, image/jpeg, image/*, */*) instead of just */* which the endpoint rejects with 406.

https://claude.ai/code/session_01D5qFc3fxKn6A431aRieGVG