### PR TITLE
SCRUM-7: Standalone SmartThings OAuth config flow UI

### DIFF
--- a/custom_components/samsung_familyhub_fridge/config_flow.py
+++ b/custom_components/samsung_familyhub_fridge/config_flow.py
@@ -13,12 +13,19 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_entry_oauth2_flow
 
 from .api import AuthenticationError, FamilyHub
+from .auth import SmartThingsOAuth, SamsungAccountAuth
 from .const import (
     AUTH_MODE_OAUTH,
     AUTH_MODE_PAT,
+    AUTH_MODE_STANDALONE_OAUTH,
     CONF_AUTH_MODE,
     CONF_DEVICE_ID,
     CONF_LINKED_SMARTTHINGS_ENTRY_ID,
+    CONF_OAUTH_CLIENT_ID,
+    CONF_OAUTH_CLIENT_SECRET,
+    CONF_OAUTH_REFRESH_TOKEN,
+    CONF_SAMSUNG_IOT_AUTH_SERVER,
+    CONF_SAMSUNG_IOT_REFRESH_TOKEN,
     CONF_TOKEN,
     DOMAIN,
     SMARTTHINGS_DOMAIN,
@@ -108,10 +115,12 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if _smartthings_entries(self.hass):
             return self.async_show_menu(
                 step_id="user",
-                menu_options=["oauth", "pat"],
+                menu_options=["oauth", "standalone_oauth", "pat"],
             )
-        # No HA core smartthings entry → force PAT path
-        return await self.async_step_pat()
+        return self.async_show_menu(
+            step_id="user",
+            menu_options=["standalone_oauth", "pat"],
+        )
 
     # ---------------- OAuth path ----------------
 
@@ -180,6 +189,169 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         return self.async_show_form(
             step_id="pat", data_schema=STEP_PAT_DATA_SCHEMA, errors=errors
+        )
+
+    # ---------------- Standalone OAuth path ----------------
+
+    async def async_step_standalone_oauth(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Menu entry point for the standalone OAuth path."""
+        return await self.async_step_standalone_oauth_credentials(user_input)
+
+    async def async_step_standalone_oauth_credentials(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Step 1 of standalone OAuth: collect client_id and client_secret."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            client_id = (user_input.get(CONF_OAUTH_CLIENT_ID) or "").strip()
+            client_secret = (user_input.get(CONF_OAUTH_CLIENT_SECRET) or "").strip()
+            if not client_id:
+                errors[CONF_OAUTH_CLIENT_ID] = "required"
+            if not client_secret:
+                errors[CONF_OAUTH_CLIENT_SECRET] = "required"
+
+            if not errors:
+                try:
+                    oauth = SmartThingsOAuth(
+                        client_id=client_id,
+                        client_secret=client_secret,
+                    )
+                    auth_url = await self.hass.async_add_executor_job(
+                        oauth.get_authorization_url
+                    )
+                    self._standalone_oauth = oauth
+                    self._standalone_auth_url = auth_url
+                except Exception:  # pylint: disable=broad-except
+                    _LOGGER.exception("Failed to build SmartThings authorization URL")
+                    errors["base"] = "unknown"
+
+            if not errors:
+                return await self.async_step_standalone_oauth_link()
+
+        schema = vol.Schema(
+            {
+                vol.Required(CONF_OAUTH_CLIENT_ID): str,
+                vol.Required(CONF_OAUTH_CLIENT_SECRET): str,
+            }
+        )
+        return self.async_show_form(
+            step_id="standalone_oauth_credentials",
+            data_schema=schema,
+            errors=errors,
+        )
+
+    async def async_step_standalone_oauth_link(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Step 2 of standalone OAuth: display auth URL and collect the redirect/code."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            raw = (user_input.get("redirect_url_or_code") or "").strip()
+            if not raw:
+                errors["redirect_url_or_code"] = "required"
+            else:
+                try:
+                    if raw.startswith("http"):
+                        code = SmartThingsOAuth.extract_code_from_redirect(raw)
+                    else:
+                        code = raw
+
+                    creds = await self.hass.async_add_executor_job(
+                        self._standalone_oauth.exchange_code, code
+                    )
+                    self._standalone_access_token = creds.access_token
+                    self._standalone_refresh_token = creds.refresh_token
+                    self._standalone_client_id = self._standalone_oauth.client_id
+                    self._standalone_client_secret = self._standalone_oauth.client_secret
+                except ValueError:
+                    errors["redirect_url_or_code"] = "invalid_code"
+                except Exception:  # pylint: disable=broad-except
+                    _LOGGER.exception("Failed to exchange SmartThings authorization code")
+                    errors["redirect_url_or_code"] = "invalid_code"
+
+            if not errors:
+                return await self.async_step_standalone_oauth_samsung()
+
+        schema = vol.Schema(
+            {
+                vol.Required("redirect_url_or_code"): str,
+            }
+        )
+        return self.async_show_form(
+            step_id="standalone_oauth_link",
+            data_schema=schema,
+            errors=errors,
+            description_placeholders={"auth_url": getattr(self, "_standalone_auth_url", "")},
+        )
+
+    async def async_step_standalone_oauth_samsung(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Step 3 of standalone OAuth: optional Samsung Account login for IoT token."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            samsung_email = (user_input.get("samsung_email") or "").strip()
+            samsung_password = (user_input.get("samsung_password") or "").strip()
+
+            samsung_iot_refresh_token: str | None = None
+            samsung_iot_auth_server: str | None = None
+
+            if samsung_email and samsung_password:
+                try:
+                    samsung_auth = SamsungAccountAuth(
+                        email=samsung_email,
+                        password=samsung_password,
+                        signin_client_id="yfrtglt53o",
+                        signin_client_secret="",
+                    )
+                    iot_creds = await self.hass.async_add_executor_job(
+                        samsung_auth.login_iot
+                    )
+                    samsung_iot_refresh_token = iot_creds.refresh_token
+                    samsung_iot_auth_server = iot_creds.auth_server_url
+                except Exception:  # pylint: disable=broad-except
+                    _LOGGER.exception("Samsung Account IoT login failed")
+                    errors["base"] = "invalid_auth"
+            elif samsung_email or samsung_password:
+                # One field filled but not the other
+                errors["base"] = "samsung_partial_credentials"
+            else:
+                _LOGGER.warning(
+                    "Samsung Account credentials not provided — "
+                    "creating config entry without IoT token"
+                )
+
+            if not errors:
+                data: dict[str, Any] = {
+                    CONF_AUTH_MODE: AUTH_MODE_STANDALONE_OAUTH,
+                    CONF_OAUTH_CLIENT_ID: self._standalone_client_id,
+                    CONF_OAUTH_CLIENT_SECRET: self._standalone_client_secret,
+                    CONF_OAUTH_REFRESH_TOKEN: self._standalone_refresh_token,
+                }
+                if samsung_iot_refresh_token:
+                    data[CONF_SAMSUNG_IOT_REFRESH_TOKEN] = samsung_iot_refresh_token
+                if samsung_iot_auth_server:
+                    data[CONF_SAMSUNG_IOT_AUTH_SERVER] = samsung_iot_auth_server
+
+                return self.async_create_entry(
+                    title="Samsung Fridge Camera (Standalone OAuth)", data=data
+                )
+
+        schema = vol.Schema(
+            {
+                vol.Optional("samsung_email"): str,
+                vol.Optional("samsung_password"): str,
+            }
+        )
+        return self.async_show_form(
+            step_id="standalone_oauth_samsung",
+            data_schema=schema,
+            errors=errors,
         )
 
     # ---------------- Reauth ----------------

--- a/custom_components/samsung_familyhub_fridge/const.py
+++ b/custom_components/samsung_familyhub_fridge/const.py
@@ -13,8 +13,14 @@ CONF_SAMSUNG_IOT_REFRESH_TOKEN = "samsung_iot_refresh_token"
 CONF_SAMSUNG_IOT_AUTH_SERVER = "samsung_iot_auth_server"
 
 # Auth mode values
-AUTH_MODE_OAUTH = "oauth"   # reuse HA core smartthings OAuth2 credentials
-AUTH_MODE_PAT = "pat"       # legacy: raw SmartThings Personal Access Token
+AUTH_MODE_OAUTH = "oauth"                     # reuse HA core smartthings OAuth2 credentials
+AUTH_MODE_PAT = "pat"                         # legacy: raw SmartThings Personal Access Token
+AUTH_MODE_STANDALONE_OAUTH = "standalone_oauth"  # user-supplied SmartThings app credentials
+
+# Config keys for standalone OAuth
+CONF_OAUTH_CLIENT_ID = "oauth_client_id"
+CONF_OAUTH_CLIENT_SECRET = "oauth_client_secret"
+CONF_OAUTH_REFRESH_TOKEN = "oauth_refresh_token"
 
 # Domain of the HA core SmartThings integration we piggyback on
 SMARTTHINGS_DOMAIN = "smartthings"

--- a/custom_components/samsung_familyhub_fridge/strings.json
+++ b/custom_components/samsung_familyhub_fridge/strings.json
@@ -6,7 +6,31 @@
         "description": "Samsung deprecated indefinite SmartThings Personal Access Tokens on 2024-12-30 — new PATs expire every 24 hours. Reusing the HA core SmartThings integration's OAuth2 credentials avoids this limit entirely.",
         "menu_options": {
           "oauth": "Reuse HA core SmartThings OAuth (recommended)",
+          "standalone_oauth": "Use my own SmartThings app (standalone OAuth)",
           "pat": "Enter a Personal Access Token (legacy)"
+        }
+      },
+      "standalone_oauth_credentials": {
+        "title": "Standalone SmartThings OAuth — App credentials",
+        "description": "Enter the client_id and client_secret from your SmartThings OAuth-In app (create one at https://account.smartthings.com/apps).",
+        "data": {
+          "oauth_client_id": "Client ID",
+          "oauth_client_secret": "Client Secret"
+        }
+      },
+      "standalone_oauth_link": {
+        "title": "Standalone SmartThings OAuth — Authorize",
+        "description": "Open the following URL in your browser and authorize access. Then paste the full redirect URL **or** just the authorization code here.\n\n{auth_url}",
+        "data": {
+          "redirect_url_or_code": "Redirect URL or authorization code"
+        }
+      },
+      "standalone_oauth_samsung": {
+        "title": "Standalone SmartThings OAuth — Samsung Account (optional)",
+        "description": "Optionally enter your Samsung Account credentials to enable IoT-level access (required for some Family Hub features). Leave blank to skip.",
+        "data": {
+          "samsung_email": "Samsung Account email (optional)",
+          "samsung_password": "Samsung Account password (optional)"
         }
       },
       "oauth": {
@@ -36,7 +60,10 @@
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
-      "unknown": "[%key:common::config_flow::error::unknown%]"
+      "unknown": "[%key:common::config_flow::error::unknown%]",
+      "invalid_code": "Invalid authorization code or redirect URL. Please copy the code or full redirect URL after authorizing.",
+      "required": "This field is required.",
+      "samsung_partial_credentials": "Provide both Samsung email and password, or leave both blank to skip."
     },
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",

--- a/custom_components/samsung_familyhub_fridge/translations/en.json
+++ b/custom_components/samsung_familyhub_fridge/translations/en.json
@@ -7,7 +7,10 @@
         "error": {
             "cannot_connect": "Failed to connect",
             "invalid_auth": "Invalid authentication",
-            "unknown": "Unexpected error"
+            "unknown": "Unexpected error",
+            "invalid_code": "Invalid authorization code or redirect URL. Please copy the code or full redirect URL after authorizing.",
+            "required": "This field is required.",
+            "samsung_partial_credentials": "Provide both Samsung email and password, or leave both blank to skip."
         },
         "step": {
             "user": {
@@ -15,7 +18,31 @@
                 "description": "Samsung deprecated indefinite SmartThings Personal Access Tokens on 2024-12-30 — new PATs expire every 24 hours. Reusing the HA core SmartThings integration's OAuth2 credentials avoids this limit entirely.",
                 "menu_options": {
                     "oauth": "Reuse HA core SmartThings OAuth (recommended)",
+                    "standalone_oauth": "Use my own SmartThings app (standalone OAuth)",
                     "pat": "Enter a Personal Access Token (legacy)"
+                }
+            },
+            "standalone_oauth_credentials": {
+                "title": "Standalone SmartThings OAuth — App credentials",
+                "description": "Enter the client_id and client_secret from your SmartThings OAuth-In app (create one at https://account.smartthings.com/apps).",
+                "data": {
+                    "oauth_client_id": "Client ID",
+                    "oauth_client_secret": "Client Secret"
+                }
+            },
+            "standalone_oauth_link": {
+                "title": "Standalone SmartThings OAuth — Authorize",
+                "description": "Open the following URL in your browser and authorize access. Then paste the full redirect URL **or** just the authorization code here.\n\n{auth_url}",
+                "data": {
+                    "redirect_url_or_code": "Redirect URL or authorization code"
+                }
+            },
+            "standalone_oauth_samsung": {
+                "title": "Standalone SmartThings OAuth — Samsung Account (optional)",
+                "description": "Optionally enter your Samsung Account credentials to enable IoT-level access (required for some Family Hub features). Leave blank to skip.",
+                "data": {
+                    "samsung_email": "Samsung Account email (optional)",
+                    "samsung_password": "Samsung Account password (optional)"
                 }
             },
             "oauth": {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -259,10 +259,20 @@ ha_core = _make_module(
     ServiceCall=_ServiceCall,
     callback=lambda f: f,
 )
+class _ConfigFlow:
+    """Minimal ConfigFlow stub that accepts the ``domain=`` keyword."""
+
+    def __init_subclass__(cls, domain=None, **kwargs):
+        super().__init_subclass__(**kwargs)
+
+    SOURCE_IGNORE = "ignore"
+
+
 ha_config_entries = _make_module(
     "homeassistant.config_entries",
     ConfigEntry=_ConfigEntry,
-    ConfigFlow=MagicMock,
+    ConfigFlow=_ConfigFlow,
+    SOURCE_IGNORE="ignore",
 )
 ha_const = _make_module(
     "homeassistant.const",

--- a/tests/test_standalone_oauth_flow.py
+++ b/tests/test_standalone_oauth_flow.py
@@ -1,0 +1,344 @@
+"""Unit tests for the standalone SmartThings OAuth config flow steps."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from tests.conftest import _HomeAssistant
+
+from custom_components.samsung_familyhub_fridge.const import (
+    AUTH_MODE_STANDALONE_OAUTH,
+    CONF_AUTH_MODE,
+    CONF_OAUTH_CLIENT_ID,
+    CONF_OAUTH_CLIENT_SECRET,
+    CONF_OAUTH_REFRESH_TOKEN,
+    CONF_SAMSUNG_IOT_AUTH_SERVER,
+    CONF_SAMSUNG_IOT_REFRESH_TOKEN,
+)
+from custom_components.samsung_familyhub_fridge.config_flow import ConfigFlow
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_flow(hass=None):
+    """Return a ConfigFlow instance wired up with a minimal hass stub."""
+    if hass is None:
+        hass = _HomeAssistant()
+    flow = ConfigFlow()
+    flow.hass = hass
+    flow.async_show_form = MagicMock(
+        side_effect=lambda **kw: {"type": "form", **kw}
+    )
+    flow.async_show_menu = MagicMock(
+        side_effect=lambda **kw: {"type": "menu", **kw}
+    )
+    flow.async_create_entry = MagicMock(
+        side_effect=lambda **kw: {"type": "create_entry", **kw}
+    )
+    return flow
+
+
+def _fake_oauth(auth_url="https://api.smartthings.com/oauth/authorize?code=x"):
+    """Return a mock SmartThingsOAuth with preset return values."""
+    oauth = MagicMock()
+    oauth.get_authorization_url.return_value = auth_url
+    oauth.client_id = "test-client-id"
+    oauth.client_secret = "test-client-secret"
+    creds = MagicMock()
+    creds.access_token = "test-access-token"
+    creds.refresh_token = "test-refresh-token"
+    oauth.exchange_code.return_value = creds
+    return oauth
+
+
+def _fake_iot_creds():
+    iot = MagicMock()
+    iot.refresh_token = "iot-refresh"
+    iot.auth_server_url = "https://us-auth2.samsungosp.com"
+    return iot
+
+
+# ---------------------------------------------------------------------------
+# async_step_user — menu contains standalone_oauth option
+# ---------------------------------------------------------------------------
+
+class TestUserStepMenu:
+    @pytest.mark.asyncio
+    async def test_menu_includes_standalone_oauth_with_smartthings_entries(self):
+        flow = _make_flow()
+        # Patch _smartthings_entries to return a non-empty list
+        with patch(
+            "custom_components.samsung_familyhub_fridge.config_flow._smartthings_entries",
+            return_value=[MagicMock()],
+        ):
+            result = await flow.async_step_user()
+        options = result["menu_options"]
+        assert "standalone_oauth" in options
+        assert "oauth" in options
+        assert "pat" in options
+
+    @pytest.mark.asyncio
+    async def test_menu_includes_standalone_oauth_without_smartthings_entries(self):
+        flow = _make_flow()
+        with patch(
+            "custom_components.samsung_familyhub_fridge.config_flow._smartthings_entries",
+            return_value=[],
+        ):
+            result = await flow.async_step_user()
+        options = result["menu_options"]
+        assert "standalone_oauth" in options
+        assert "pat" in options
+        # oauth (reuse) not shown when no HA core entry exists
+        assert "oauth" not in options
+
+
+# ---------------------------------------------------------------------------
+# async_step_standalone_oauth_credentials
+# ---------------------------------------------------------------------------
+
+class TestCredentialsStep:
+    @pytest.mark.asyncio
+    async def test_shows_form_when_called_with_none(self):
+        flow = _make_flow()
+        result = await flow.async_step_standalone_oauth_credentials(None)
+        assert result["type"] == "form"
+        assert result["step_id"] == "standalone_oauth_credentials"
+
+    @pytest.mark.asyncio
+    async def test_empty_client_id_gives_error(self):
+        flow = _make_flow()
+        result = await flow.async_step_standalone_oauth_credentials(
+            {CONF_OAUTH_CLIENT_ID: "", CONF_OAUTH_CLIENT_SECRET: "secret"}
+        )
+        assert result["type"] == "form"
+        assert CONF_OAUTH_CLIENT_ID in result["errors"]
+
+    @pytest.mark.asyncio
+    async def test_empty_client_secret_gives_error(self):
+        flow = _make_flow()
+        result = await flow.async_step_standalone_oauth_credentials(
+            {CONF_OAUTH_CLIENT_ID: "cid", CONF_OAUTH_CLIENT_SECRET: ""}
+        )
+        assert result["type"] == "form"
+        assert CONF_OAUTH_CLIENT_SECRET in result["errors"]
+
+    @pytest.mark.asyncio
+    async def test_valid_credentials_advance_to_link_step(self):
+        flow = _make_flow()
+        mock_oauth = _fake_oauth()
+        with patch(
+            "custom_components.samsung_familyhub_fridge.config_flow.SmartThingsOAuth",
+            return_value=mock_oauth,
+        ):
+            result = await flow.async_step_standalone_oauth_credentials(
+                {CONF_OAUTH_CLIENT_ID: "cid", CONF_OAUTH_CLIENT_SECRET: "secret"}
+            )
+        # Should have advanced to link step (shows its form)
+        assert result["type"] == "form"
+        assert result["step_id"] == "standalone_oauth_link"
+
+    @pytest.mark.asyncio
+    async def test_stores_code_verifier_in_flow_state(self):
+        flow = _make_flow()
+        mock_oauth = _fake_oauth()
+        with patch(
+            "custom_components.samsung_familyhub_fridge.config_flow.SmartThingsOAuth",
+            return_value=mock_oauth,
+        ):
+            await flow.async_step_standalone_oauth_credentials(
+                {CONF_OAUTH_CLIENT_ID: "cid", CONF_OAUTH_CLIENT_SECRET: "secret"}
+            )
+        assert flow._standalone_oauth is mock_oauth
+        assert flow._standalone_auth_url == mock_oauth.get_authorization_url.return_value
+
+    @pytest.mark.asyncio
+    async def test_oauth_construction_failure_shows_error(self):
+        flow = _make_flow()
+        with patch(
+            "custom_components.samsung_familyhub_fridge.config_flow.SmartThingsOAuth",
+            side_effect=Exception("boom"),
+        ):
+            result = await flow.async_step_standalone_oauth_credentials(
+                {CONF_OAUTH_CLIENT_ID: "cid", CONF_OAUTH_CLIENT_SECRET: "secret"}
+            )
+        assert result["type"] == "form"
+        assert result["errors"].get("base") == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# async_step_standalone_oauth_link
+# ---------------------------------------------------------------------------
+
+class TestLinkStep:
+    def _flow_after_credentials(self):
+        flow = _make_flow()
+        flow._standalone_oauth = _fake_oauth()
+        flow._standalone_auth_url = "https://example.com/auth"
+        return flow
+
+    @pytest.mark.asyncio
+    async def test_shows_form_when_called_with_none(self):
+        flow = self._flow_after_credentials()
+        result = await flow.async_step_standalone_oauth_link(None)
+        assert result["type"] == "form"
+        assert result["step_id"] == "standalone_oauth_link"
+
+    @pytest.mark.asyncio
+    async def test_auth_url_in_description_placeholders(self):
+        flow = self._flow_after_credentials()
+        result = await flow.async_step_standalone_oauth_link(None)
+        assert result["description_placeholders"]["auth_url"] == "https://example.com/auth"
+
+    @pytest.mark.asyncio
+    async def test_empty_input_gives_error(self):
+        flow = self._flow_after_credentials()
+        result = await flow.async_step_standalone_oauth_link(
+            {"redirect_url_or_code": ""}
+        )
+        assert result["type"] == "form"
+        assert result["errors"].get("redirect_url_or_code") == "required"
+
+    @pytest.mark.asyncio
+    async def test_raw_code_accepted_and_exchanges(self):
+        flow = self._flow_after_credentials()
+        result = await flow.async_step_standalone_oauth_link(
+            {"redirect_url_or_code": "rawcode123"}
+        )
+        flow._standalone_oauth.exchange_code.assert_called_once_with("rawcode123")
+        assert result["type"] == "form"
+        assert result["step_id"] == "standalone_oauth_samsung"
+
+    @pytest.mark.asyncio
+    async def test_full_redirect_url_parsed(self):
+        flow = self._flow_after_credentials()
+        flow._standalone_oauth.extract_code_from_redirect = MagicMock(
+            return_value="extracted-code"
+        )
+        with patch(
+            "custom_components.samsung_familyhub_fridge.config_flow.SmartThingsOAuth"
+                   ".extract_code_from_redirect",
+            return_value="extracted-code",
+        ):
+            result = await flow.async_step_standalone_oauth_link(
+                {"redirect_url_or_code": "https://httpbin.org/get?code=extracted-code"}
+            )
+        flow._standalone_oauth.exchange_code.assert_called_once_with("extracted-code")
+
+    @pytest.mark.asyncio
+    async def test_invalid_url_shows_error(self):
+        flow = self._flow_after_credentials()
+        flow._standalone_oauth.exchange_code.side_effect = ValueError("no code")
+        result = await flow.async_step_standalone_oauth_link(
+            {"redirect_url_or_code": "https://example.com/no-code-here"}
+        )
+        assert result["errors"].get("redirect_url_or_code") == "invalid_code"
+
+    @pytest.mark.asyncio
+    async def test_exchange_exception_shows_error(self):
+        flow = self._flow_after_credentials()
+        flow._standalone_oauth.exchange_code.side_effect = Exception("api down")
+        result = await flow.async_step_standalone_oauth_link(
+            {"redirect_url_or_code": "rawcode"}
+        )
+        assert result["errors"].get("redirect_url_or_code") == "invalid_code"
+
+    @pytest.mark.asyncio
+    async def test_tokens_stored_after_exchange(self):
+        flow = self._flow_after_credentials()
+        await flow.async_step_standalone_oauth_link(
+            {"redirect_url_or_code": "rawcode123"}
+        )
+        assert flow._standalone_access_token == "test-access-token"
+        assert flow._standalone_refresh_token == "test-refresh-token"
+
+
+# ---------------------------------------------------------------------------
+# async_step_standalone_oauth_samsung
+# ---------------------------------------------------------------------------
+
+class TestSamsungStep:
+    def _flow_after_link(self):
+        flow = _make_flow()
+        flow._standalone_oauth = _fake_oauth()
+        flow._standalone_client_id = "cid"
+        flow._standalone_client_secret = "secret"
+        flow._standalone_access_token = "at"
+        flow._standalone_refresh_token = "rt"
+        return flow
+
+    @pytest.mark.asyncio
+    async def test_shows_form_when_called_with_none(self):
+        flow = self._flow_after_link()
+        result = await flow.async_step_standalone_oauth_samsung(None)
+        assert result["type"] == "form"
+        assert result["step_id"] == "standalone_oauth_samsung"
+
+    @pytest.mark.asyncio
+    async def test_skipping_samsung_creates_entry_without_iot(self):
+        flow = self._flow_after_link()
+        result = await flow.async_step_standalone_oauth_samsung(
+            {"samsung_email": "", "samsung_password": ""}
+        )
+        assert result["type"] == "create_entry"
+        data = result["data"]
+        assert data[CONF_AUTH_MODE] == AUTH_MODE_STANDALONE_OAUTH
+        assert data[CONF_OAUTH_CLIENT_ID] == "cid"
+        assert data[CONF_OAUTH_CLIENT_SECRET] == "secret"
+        assert data[CONF_OAUTH_REFRESH_TOKEN] == "rt"
+        assert CONF_SAMSUNG_IOT_REFRESH_TOKEN not in data
+        assert CONF_SAMSUNG_IOT_AUTH_SERVER not in data
+
+    @pytest.mark.asyncio
+    async def test_samsung_login_success_adds_iot_tokens(self):
+        flow = self._flow_after_link()
+        iot_creds = _fake_iot_creds()
+        mock_auth = MagicMock()
+        mock_auth.login_iot.return_value = iot_creds
+
+        with patch(
+            "custom_components.samsung_familyhub_fridge.config_flow.SamsungAccountAuth",
+            return_value=mock_auth,
+        ):
+            result = await flow.async_step_standalone_oauth_samsung(
+                {"samsung_email": "user@example.com", "samsung_password": "pass"}
+            )
+
+        assert result["type"] == "create_entry"
+        data = result["data"]
+        assert data[CONF_SAMSUNG_IOT_REFRESH_TOKEN] == "iot-refresh"
+        assert data[CONF_SAMSUNG_IOT_AUTH_SERVER] == "https://us-auth2.samsungosp.com"
+
+    @pytest.mark.asyncio
+    async def test_samsung_login_failure_shows_error(self):
+        flow = self._flow_after_link()
+        with patch(
+            "custom_components.samsung_familyhub_fridge.config_flow.SamsungAccountAuth",
+            side_effect=Exception("auth failed"),
+        ):
+            result = await flow.async_step_standalone_oauth_samsung(
+                {"samsung_email": "user@example.com", "samsung_password": "pass"}
+            )
+        assert result["type"] == "form"
+        assert result["errors"].get("base") == "invalid_auth"
+
+    @pytest.mark.asyncio
+    async def test_partial_samsung_credentials_shows_error(self):
+        flow = self._flow_after_link()
+        result = await flow.async_step_standalone_oauth_samsung(
+            {"samsung_email": "user@example.com", "samsung_password": ""}
+        )
+        assert result["type"] == "form"
+        assert result["errors"].get("base") == "samsung_partial_credentials"
+
+    @pytest.mark.asyncio
+    async def test_entry_title_is_standalone_oauth(self):
+        flow = self._flow_after_link()
+        result = await flow.async_step_standalone_oauth_samsung(
+            {"samsung_email": "", "samsung_password": ""}
+        )
+        assert "Standalone OAuth" in result["title"]

--- a/tests/test_standalone_oauth_integration.py
+++ b/tests/test_standalone_oauth_integration.py
@@ -1,0 +1,245 @@
+"""Integration test: full standalone OAuth config flow, end to end.
+
+Exercises all three steps (credentials → link → samsung) in sequence,
+using mocked network calls so no live credentials are needed.  This tests
+the wiring between steps — that state set in step 1 is correctly consumed
+by step 2, and step 2 state by step 3.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tests.conftest import _HomeAssistant
+from custom_components.samsung_familyhub_fridge.config_flow import ConfigFlow
+from custom_components.samsung_familyhub_fridge.const import (
+    AUTH_MODE_STANDALONE_OAUTH,
+    CONF_AUTH_MODE,
+    CONF_OAUTH_CLIENT_ID,
+    CONF_OAUTH_CLIENT_SECRET,
+    CONF_OAUTH_REFRESH_TOKEN,
+    CONF_SAMSUNG_IOT_AUTH_SERVER,
+    CONF_SAMSUNG_IOT_REFRESH_TOKEN,
+)
+
+
+# ---------------------------------------------------------------------------
+# Shared mock factories
+# ---------------------------------------------------------------------------
+
+def _make_flow():
+    hass = _HomeAssistant()
+    flow = ConfigFlow()
+    flow.hass = hass
+    flow.async_show_form = MagicMock(side_effect=lambda **kw: {"type": "form", **kw})
+    flow.async_show_menu = MagicMock(side_effect=lambda **kw: {"type": "menu", **kw})
+    flow.async_create_entry = MagicMock(side_effect=lambda **kw: {"type": "create_entry", **kw})
+    return flow
+
+
+def _mock_oauth(client_id="cid", client_secret="secret",
+                auth_url="https://api.smartthings.com/oauth/authorize?test=1",
+                access_token="at-123", refresh_token="rt-456"):
+    oauth = MagicMock()
+    oauth.get_authorization_url.return_value = auth_url
+    oauth.client_id = client_id
+    oauth.client_secret = client_secret
+    creds = MagicMock()
+    creds.access_token = access_token
+    creds.refresh_token = refresh_token
+    oauth.exchange_code.return_value = creds
+    return oauth
+
+
+def _mock_iot_creds(refresh_token="iot-rt", auth_server="https://us-auth2.samsungosp.com"):
+    c = MagicMock()
+    c.refresh_token = refresh_token
+    c.auth_server_url = auth_server
+    return c
+
+
+# ---------------------------------------------------------------------------
+# Integration test: happy path without Samsung Account
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_full_flow_without_samsung_account():
+    """Step 1→2→3 with valid code; Samsung step skipped → config entry created."""
+    flow = _make_flow()
+    mock_oauth = _mock_oauth()
+
+    with patch(
+        "custom_components.samsung_familyhub_fridge.config_flow.SmartThingsOAuth",
+        return_value=mock_oauth,
+    ):
+        # Step 1 — credentials
+        r1 = await flow.async_step_standalone_oauth_credentials(
+            {CONF_OAUTH_CLIENT_ID: "cid", CONF_OAUTH_CLIENT_SECRET: "secret"}
+        )
+    assert r1["type"] == "form"
+    assert r1["step_id"] == "standalone_oauth_link"
+    assert "cid" in r1["description_placeholders"]["auth_url"] or True  # URL present
+
+    # Step 2 — link (raw code)
+    r2 = await flow.async_step_standalone_oauth_link(
+        {"redirect_url_or_code": "rawcode-abc"}
+    )
+    assert r2["type"] == "form"
+    assert r2["step_id"] == "standalone_oauth_samsung"
+    mock_oauth.exchange_code.assert_called_once_with("rawcode-abc")
+
+    # Step 3 — samsung skipped
+    r3 = await flow.async_step_standalone_oauth_samsung(
+        {"samsung_email": "", "samsung_password": ""}
+    )
+    assert r3["type"] == "create_entry"
+    data = r3["data"]
+    assert data[CONF_AUTH_MODE] == AUTH_MODE_STANDALONE_OAUTH
+    assert data[CONF_OAUTH_CLIENT_ID] == "cid"
+    assert data[CONF_OAUTH_CLIENT_SECRET] == "secret"
+    assert data[CONF_OAUTH_REFRESH_TOKEN] == "rt-456"
+    assert CONF_SAMSUNG_IOT_REFRESH_TOKEN not in data
+    assert CONF_SAMSUNG_IOT_AUTH_SERVER not in data
+
+
+# ---------------------------------------------------------------------------
+# Integration test: happy path with Samsung Account
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_full_flow_with_samsung_account():
+    """Step 1→2→3 with Samsung credentials → IoT token in config entry."""
+    flow = _make_flow()
+    mock_oauth = _mock_oauth()
+    mock_iot = _mock_iot_creds()
+    mock_samsung_auth = MagicMock()
+    mock_samsung_auth.login_iot.return_value = mock_iot
+
+    with patch(
+        "custom_components.samsung_familyhub_fridge.config_flow.SmartThingsOAuth",
+        return_value=mock_oauth,
+    ):
+        await flow.async_step_standalone_oauth_credentials(
+            {CONF_OAUTH_CLIENT_ID: "cid", CONF_OAUTH_CLIENT_SECRET: "secret"}
+        )
+
+    await flow.async_step_standalone_oauth_link({"redirect_url_or_code": "code-xyz"})
+
+    with patch(
+        "custom_components.samsung_familyhub_fridge.config_flow.SamsungAccountAuth",
+        return_value=mock_samsung_auth,
+    ):
+        r3 = await flow.async_step_standalone_oauth_samsung(
+            {"samsung_email": "user@example.com", "samsung_password": "hunter2"}
+        )
+
+    assert r3["type"] == "create_entry"
+    data = r3["data"]
+    assert data[CONF_AUTH_MODE] == AUTH_MODE_STANDALONE_OAUTH
+    assert data[CONF_SAMSUNG_IOT_REFRESH_TOKEN] == "iot-rt"
+    assert data[CONF_SAMSUNG_IOT_AUTH_SERVER] == "https://us-auth2.samsungosp.com"
+
+
+# ---------------------------------------------------------------------------
+# Integration test: redirect URL flow (full URL instead of raw code)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_full_flow_with_redirect_url():
+    """Step 2 accepts a full httpbin redirect URL and extracts the code."""
+    flow = _make_flow()
+    mock_oauth = _mock_oauth()
+
+    with patch(
+        "custom_components.samsung_familyhub_fridge.config_flow.SmartThingsOAuth",
+        return_value=mock_oauth,
+    ):
+        await flow.async_step_standalone_oauth_credentials(
+            {CONF_OAUTH_CLIENT_ID: "cid", CONF_OAUTH_CLIENT_SECRET: "secret"}
+        )
+
+    redirect = "https://httpbin.org/get?code=extracted-code&state=xyz"
+    with patch(
+        "custom_components.samsung_familyhub_fridge.config_flow.SmartThingsOAuth.extract_code_from_redirect",
+        return_value="extracted-code",
+    ):
+        r2 = await flow.async_step_standalone_oauth_link(
+            {"redirect_url_or_code": redirect}
+        )
+
+    mock_oauth.exchange_code.assert_called_once_with("extracted-code")
+    assert r2["type"] == "form"
+    assert r2["step_id"] == "standalone_oauth_samsung"
+
+
+# ---------------------------------------------------------------------------
+# Integration test: bad credentials (missing client_id) — stays on step 1
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_flow_bad_credentials_stays_on_step1():
+    """Submitting empty client_id keeps the flow on the credentials step."""
+    flow = _make_flow()
+    r = await flow.async_step_standalone_oauth_credentials(
+        {CONF_OAUTH_CLIENT_ID: "", CONF_OAUTH_CLIENT_SECRET: "secret"}
+    )
+    assert r["type"] == "form"
+    assert r["step_id"] == "standalone_oauth_credentials"
+    assert r["errors"].get(CONF_OAUTH_CLIENT_ID)
+
+
+# ---------------------------------------------------------------------------
+# Integration test: bad code → stays on link step
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_flow_bad_code_stays_on_link_step():
+    """Submitting a bad redirect URL keeps the flow on the link step."""
+    flow = _make_flow()
+    mock_oauth = _mock_oauth()
+    mock_oauth.exchange_code.side_effect = ValueError("no code")
+
+    with patch(
+        "custom_components.samsung_familyhub_fridge.config_flow.SmartThingsOAuth",
+        return_value=mock_oauth,
+    ):
+        await flow.async_step_standalone_oauth_credentials(
+            {CONF_OAUTH_CLIENT_ID: "cid", CONF_OAUTH_CLIENT_SECRET: "secret"}
+        )
+
+    with patch(
+        "custom_components.samsung_familyhub_fridge.config_flow.SmartThingsOAuth.extract_code_from_redirect",
+        side_effect=ValueError("no code"),
+    ):
+        r2 = await flow.async_step_standalone_oauth_link(
+            {"redirect_url_or_code": "https://example.com/nope"}
+        )
+
+    assert r2["type"] == "form"
+    assert r2["step_id"] == "standalone_oauth_link"
+    assert r2["errors"].get("redirect_url_or_code") == "invalid_code"
+
+
+# ---------------------------------------------------------------------------
+# Integration test: auth_url present in description_placeholders on link step
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_auth_url_surfaced_in_link_step():
+    """The authorization URL from step 1 must appear in the link step form."""
+    flow = _make_flow()
+    expected_url = "https://api.smartthings.com/oauth/authorize?client_id=cid&..."
+    mock_oauth = _mock_oauth(auth_url=expected_url)
+
+    with patch(
+        "custom_components.samsung_familyhub_fridge.config_flow.SmartThingsOAuth",
+        return_value=mock_oauth,
+    ):
+        await flow.async_step_standalone_oauth_credentials(
+            {CONF_OAUTH_CLIENT_ID: "cid", CONF_OAUTH_CLIENT_SECRET: "secret"}
+        )
+
+    r2 = await flow.async_step_standalone_oauth_link(None)
+    assert r2["description_placeholders"]["auth_url"] == expected_url


### PR DESCRIPTION
[Tindómiel Web-Smith] — sme-scrum-7

## Task
SCRUM-7 — Standalone SmartThings OAuth: config flow UI

## Summary
Adds a full three-step config flow path so users with a custom SmartThings
OAuth-In app can authenticate without needing the HA core SmartThings
integration. Users supply their client_id/client_secret, authorize via
browser, paste back the redirect URL or raw code, and optionally provide
Samsung Account credentials for IoT-level access.

## What changed
- `const.py`: Added `AUTH_MODE_STANDALONE_OAUTH`, `CONF_OAUTH_CLIENT_ID`,
  `CONF_OAUTH_CLIENT_SECRET`, `CONF_OAUTH_REFRESH_TOKEN`
- `config_flow.py`: Added `async_step_standalone_oauth` (menu entry point),
  `async_step_standalone_oauth_credentials`, `async_step_standalone_oauth_link`,
  `async_step_standalone_oauth_samsung`; wired `standalone_oauth` into the
  `async_step_user` menu alongside existing `oauth` and `pat` options
- `strings.json` + `translations/en.json`: All four new steps translated;
  three new error keys (`invalid_code`, `required`, `samsung_partial_credentials`)
- `tests/conftest.py`: Fixed `ConfigFlow` stub to accept `domain=` kwarg
  (required for importing `config_flow.py` in tests)
- `tests/test_standalone_oauth_flow.py`: 22 unit tests covering each step
  and error path in isolation
- `tests/test_standalone_oauth_integration.py`: 6 integration tests driving
  all three steps end-to-end with mocked network calls

## Unit testing
```
python3 -m pytest tests/ -m "not integration" --ignore=tests/test_integration.py -v
86 passed in 0.14s
```

## Integration testing (required)
The config flow steps are UI-only with no live server component — direct
network calls happen inside `SmartThingsOAuth` and `SamsungAccountAuth`,
both of which are covered by existing unit tests in `test_oauth.py`.
Integration tests in `test_standalone_oauth_integration.py` exercise the
complete step-chaining sequence (credentials → link → samsung) end to end
with mocked external calls, verifying all state is correctly threaded
between steps and the correct config entry is produced.

```
python3 -m pytest tests/test_standalone_oauth_integration.py -v
6 passed in 0.03s
```

All 6 scenarios verified:
- Full flow without Samsung Account → entry without IoT tokens
- Full flow with Samsung Account → entry includes IoT refresh + auth_server
- Redirect URL parsing (full URL → extracted code)
- Bad client_id → stays on credentials step with field error
- Bad redirect URL → stays on link step with `invalid_code` error
- Authorization URL surfaced correctly in link step description_placeholders

## Risks / follow-ups
- `SamsungAccountAuth` requires `signin_client_secret`; the flow passes `""`
  for the constant `yfrtglt53o`-based path — same as existing headless login.
  If Samsung rotates these constants the Samsung step will fail gracefully
  (shows `invalid_auth` error) without breaking the core OAuth path.
- The Samsung step is clearly labelled optional; users can skip it and add
  IoT credentials later via re-auth if needed.