### PR TITLE
SCRUM-6: Standalone SmartThings OAuth config flow

### DIFF
--- a/custom_components/samsung_familyhub_fridge/config_flow.py
+++ b/custom_components/samsung_familyhub_fridge/config_flow.py
@@ -13,12 +13,20 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_entry_oauth2_flow
 
 from .api import AuthenticationError, FamilyHub
+from .auth import AuthError, SamsungAccountAuth, SmartThingsOAuth
+from .auth import SAMSUNG_LOGIN_CLIENT_ID
 from .const import (
     AUTH_MODE_OAUTH,
     AUTH_MODE_PAT,
+    AUTH_MODE_STANDALONE_OAUTH,
     CONF_AUTH_MODE,
     CONF_DEVICE_ID,
     CONF_LINKED_SMARTTHINGS_ENTRY_ID,
+    CONF_OAUTH_CLIENT_ID,
+    CONF_OAUTH_CLIENT_SECRET,
+    CONF_OAUTH_REFRESH_TOKEN,
+    CONF_SAMSUNG_IOT_AUTH_SERVER,
+    CONF_SAMSUNG_IOT_REFRESH_TOKEN,
     CONF_TOKEN,
     DOMAIN,
     SMARTTHINGS_DOMAIN,
@@ -108,10 +116,13 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if _smartthings_entries(self.hass):
             return self.async_show_menu(
                 step_id="user",
-                menu_options=["oauth", "pat"],
+                menu_options=["oauth", "standalone_oauth", "pat"],
             )
-        # No HA core smartthings entry → force PAT path
-        return await self.async_step_pat()
+        # No HA core smartthings entry → offer standalone OAuth or PAT
+        return self.async_show_menu(
+            step_id="user",
+            menu_options=["standalone_oauth", "pat"],
+        )
 
     # ---------------- OAuth path ----------------
 
@@ -153,6 +164,145 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         )
         return self.async_show_form(
             step_id="oauth", data_schema=schema, errors=errors
+        )
+
+    # ---------------- Standalone OAuth path ----------------
+
+    async def async_step_standalone_oauth(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Bridge: HA resolves menu option 'standalone_oauth' to this method."""
+        return await self.async_step_standalone_oauth_credentials(user_input)
+
+    async def async_step_standalone_oauth_credentials(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Step 1 of standalone OAuth: collect client_id and client_secret."""
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            client_id = user_input.get(CONF_OAUTH_CLIENT_ID, "").strip()
+            client_secret = user_input.get(CONF_OAUTH_CLIENT_SECRET, "").strip()
+            if not client_id:
+                errors[CONF_OAUTH_CLIENT_ID] = "required"
+            elif not client_secret:
+                errors[CONF_OAUTH_CLIENT_SECRET] = "required"
+            else:
+                oauth = SmartThingsOAuth(
+                    client_id=client_id,
+                    client_secret=client_secret,
+                )
+                self._standalone_oauth = oauth
+                self._standalone_client_id = client_id
+                self._standalone_client_secret = client_secret
+                self._standalone_auth_url = oauth.get_authorization_url()
+                return await self.async_step_standalone_oauth_link()
+
+        schema = vol.Schema(
+            {
+                vol.Required(CONF_OAUTH_CLIENT_ID): str,
+                vol.Required(CONF_OAUTH_CLIENT_SECRET): str,
+            }
+        )
+        return self.async_show_form(
+            step_id="standalone_oauth_credentials",
+            data_schema=schema,
+            errors=errors,
+        )
+
+    async def async_step_standalone_oauth_link(
+        self,
+        user_input: dict[str, Any] | None = None,
+    ) -> FlowResult:
+        """Step 2 of standalone OAuth: display auth URL, collect redirect or code."""
+        errors: dict[str, str] = {}
+        oauth: SmartThingsOAuth | None = getattr(self, "_standalone_oauth", None)
+        if oauth is None:
+            return await self.async_step_standalone_oauth_credentials()
+
+        auth_url: str = getattr(self, "_standalone_auth_url", "") or oauth.get_authorization_url()
+
+        if user_input is not None:
+            raw = user_input.get("redirect_url_or_code", "").strip()
+            if not raw:
+                errors["redirect_url_or_code"] = "required"
+            else:
+                try:
+                    if raw.startswith("http"):
+                        code = SmartThingsOAuth.extract_code_from_redirect(raw)
+                    else:
+                        code = raw
+                    creds = await self.hass.async_add_executor_job(oauth.exchange_code, code)
+                except ValueError:
+                    errors["redirect_url_or_code"] = "invalid_redirect_url"
+                except Exception:  # pylint: disable=broad-except
+                    _LOGGER.exception("Code exchange failed")
+                    errors["redirect_url_or_code"] = "code_exchange_failed"
+                else:
+                    self._standalone_access_token = creds.access_token
+                    self._standalone_refresh_token = creds.refresh_token
+                    return await self.async_step_standalone_oauth_samsung()
+
+        schema = vol.Schema({"redirect_url_or_code": str})
+        return self.async_show_form(
+            step_id="standalone_oauth_link",
+            data_schema=schema,
+            errors=errors,
+            description_placeholders={"authorization_url": auth_url},
+        )
+
+    async def async_step_standalone_oauth_samsung(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Step 3 of standalone OAuth: optional Samsung Account login."""
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            email = (user_input.get("samsung_email") or "").strip()
+            password = (user_input.get("samsung_password") or "").strip()
+            data: dict[str, Any] = {
+                CONF_AUTH_MODE: AUTH_MODE_STANDALONE_OAUTH,
+                CONF_OAUTH_CLIENT_ID: self._standalone_client_id,
+                CONF_OAUTH_CLIENT_SECRET: self._standalone_client_secret,
+                CONF_OAUTH_REFRESH_TOKEN: self._standalone_refresh_token,
+            }
+            if email and password:
+                try:
+                    samsung_auth = SamsungAccountAuth(
+                        email=email,
+                        password=password,
+                        signin_client_id=SAMSUNG_LOGIN_CLIENT_ID,
+                        signin_client_secret="",
+                    )
+                    iot_creds = await self.hass.async_add_executor_job(
+                        samsung_auth.login_iot
+                    )
+                    data[CONF_SAMSUNG_IOT_REFRESH_TOKEN] = iot_creds.refresh_token
+                    data[CONF_SAMSUNG_IOT_AUTH_SERVER] = iot_creds.auth_server_url
+                except AuthError as err:
+                    _LOGGER.warning("Samsung Account login failed: %s", err)
+                    errors["base"] = "samsung_login_failed"
+                except Exception:  # pylint: disable=broad-except
+                    _LOGGER.exception("Unexpected error during Samsung login")
+                    errors["base"] = "unknown"
+            else:
+                _LOGGER.warning(
+                    "Samsung Account credentials not provided — IoT features unavailable"
+                )
+
+            if not errors:
+                return self.async_create_entry(
+                    title="Samsung Fridge Camera (Standalone OAuth)", data=data
+                )
+
+        schema = vol.Schema(
+            {
+                vol.Optional("samsung_email"): str,
+                vol.Optional("samsung_password"): str,
+            }
+        )
+        return self.async_show_form(
+            step_id="standalone_oauth_samsung",
+            data_schema=schema,
+            errors=errors,
         )
 
     # ---------------- PAT path (legacy) ----------------

--- a/custom_components/samsung_familyhub_fridge/const.py
+++ b/custom_components/samsung_familyhub_fridge/const.py
@@ -13,8 +13,14 @@ CONF_SAMSUNG_IOT_REFRESH_TOKEN = "samsung_iot_refresh_token"
 CONF_SAMSUNG_IOT_AUTH_SERVER = "samsung_iot_auth_server"
 
 # Auth mode values
-AUTH_MODE_OAUTH = "oauth"   # reuse HA core smartthings OAuth2 credentials
-AUTH_MODE_PAT = "pat"       # legacy: raw SmartThings Personal Access Token
+AUTH_MODE_OAUTH = "oauth"             # reuse HA core smartthings OAuth2 credentials
+AUTH_MODE_PAT = "pat"                 # legacy: raw SmartThings Personal Access Token
+AUTH_MODE_STANDALONE_OAUTH = "standalone_oauth"  # custom SmartThings app credentials
+
+# Standalone OAuth config keys
+CONF_OAUTH_CLIENT_ID = "oauth_client_id"
+CONF_OAUTH_CLIENT_SECRET = "oauth_client_secret"
+CONF_OAUTH_REFRESH_TOKEN = "oauth_refresh_token"
 
 # Domain of the HA core SmartThings integration we piggyback on
 SMARTTHINGS_DOMAIN = "smartthings"

--- a/custom_components/samsung_familyhub_fridge/strings.json
+++ b/custom_components/samsung_familyhub_fridge/strings.json
@@ -6,7 +6,31 @@
         "description": "Samsung deprecated indefinite SmartThings Personal Access Tokens on 2024-12-30 — new PATs expire every 24 hours. Reusing the HA core SmartThings integration's OAuth2 credentials avoids this limit entirely.",
         "menu_options": {
           "oauth": "Reuse HA core SmartThings OAuth (recommended)",
+          "standalone_oauth": "Standalone SmartThings OAuth (custom app)",
           "pat": "Enter a Personal Access Token (legacy)"
+        }
+      },
+      "standalone_oauth_credentials": {
+        "title": "Standalone SmartThings OAuth — App credentials",
+        "description": "Enter the client_id and client_secret from your SmartThings OAuth-In app (created via `smartthings apps:create`).",
+        "data": {
+          "oauth_client_id": "Client ID",
+          "oauth_client_secret": "Client Secret"
+        }
+      },
+      "standalone_oauth_link": {
+        "title": "Standalone SmartThings OAuth — Authorize",
+        "description": "Open this URL in a browser to authorize:\n\n`{authorization_url}`\n\nAfter authorizing, paste the full redirect URL or the raw authorization code below.",
+        "data": {
+          "redirect_url_or_code": "Redirect URL or authorization code"
+        }
+      },
+      "standalone_oauth_samsung": {
+        "title": "Standalone SmartThings OAuth — Samsung Account (optional)",
+        "description": "Optionally provide Samsung Account credentials to enable IoT camera features. Leave both fields empty to skip — the integration will work without live image downloads.",
+        "data": {
+          "samsung_email": "Samsung Account email (optional)",
+          "samsung_password": "Samsung Account password (optional)"
         }
       },
       "oauth": {
@@ -36,7 +60,11 @@
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
-      "unknown": "[%key:common::config_flow::error::unknown%]"
+      "unknown": "[%key:common::config_flow::error::unknown%]",
+      "required": "This field is required",
+      "invalid_redirect_url": "No authorization code found in the URL. Check the URL and try again.",
+      "code_exchange_failed": "Failed to exchange the authorization code. Check your credentials and try again.",
+      "samsung_login_failed": "Samsung Account login failed. Check your email and password. Accounts with 2FA are not supported."
     },
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",

--- a/custom_components/samsung_familyhub_fridge/translations/en.json
+++ b/custom_components/samsung_familyhub_fridge/translations/en.json
@@ -7,7 +7,11 @@
         "error": {
             "cannot_connect": "Failed to connect",
             "invalid_auth": "Invalid authentication",
-            "unknown": "Unexpected error"
+            "unknown": "Unexpected error",
+            "required": "This field is required",
+            "invalid_redirect_url": "No authorization code found in the URL. Check the URL and try again.",
+            "code_exchange_failed": "Failed to exchange the authorization code. Check your credentials and try again.",
+            "samsung_login_failed": "Samsung Account login failed. Check your email and password. Accounts with 2FA are not supported."
         },
         "step": {
             "user": {
@@ -15,7 +19,31 @@
                 "description": "Samsung deprecated indefinite SmartThings Personal Access Tokens on 2024-12-30 — new PATs expire every 24 hours. Reusing the HA core SmartThings integration's OAuth2 credentials avoids this limit entirely.",
                 "menu_options": {
                     "oauth": "Reuse HA core SmartThings OAuth (recommended)",
+                    "standalone_oauth": "Standalone SmartThings OAuth (custom app)",
                     "pat": "Enter a Personal Access Token (legacy)"
+                }
+            },
+            "standalone_oauth_credentials": {
+                "title": "Standalone SmartThings OAuth — App credentials",
+                "description": "Enter the client_id and client_secret from your SmartThings OAuth-In app (created via `smartthings apps:create`).",
+                "data": {
+                    "oauth_client_id": "Client ID",
+                    "oauth_client_secret": "Client Secret"
+                }
+            },
+            "standalone_oauth_link": {
+                "title": "Standalone SmartThings OAuth — Authorize",
+                "description": "Open this URL in a browser to authorize:\n\n`{authorization_url}`\n\nAfter authorizing, paste the full redirect URL or the raw authorization code below.",
+                "data": {
+                    "redirect_url_or_code": "Redirect URL or authorization code"
+                }
+            },
+            "standalone_oauth_samsung": {
+                "title": "Standalone SmartThings OAuth — Samsung Account (optional)",
+                "description": "Optionally provide Samsung Account credentials to enable IoT camera features. Leave both fields empty to skip — the integration will work without live image downloads.",
+                "data": {
+                    "samsung_email": "Samsung Account email (optional)",
+                    "samsung_password": "Samsung Account password (optional)"
                 }
             },
             "oauth": {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -259,10 +259,44 @@ ha_core = _make_module(
     ServiceCall=_ServiceCall,
     callback=lambda f: f,
 )
+class _ConfigFlowBase:
+    """Stub base class for config_entries.ConfigFlow.
+
+    Accepts `domain=` as a keyword in subclass declarations (the real HA base
+    class uses a metaclass to capture it; here we just ignore it so the
+    `class ConfigFlow(_ConfigFlowBase, domain=DOMAIN)` pattern works in tests).
+    """
+
+    def __init_subclass__(cls, domain: str = "", **kwargs):
+        super().__init_subclass__(**kwargs)
+
+    def async_show_menu(self, *, step_id, menu_options):
+        return {"type": "menu", "step_id": step_id, "menu_options": menu_options}
+
+    def async_show_form(self, *, step_id, data_schema=None, errors=None, description_placeholders=None):
+        return {
+            "type": "form",
+            "step_id": step_id,
+            "data_schema": data_schema,
+            "errors": errors or {},
+            "description_placeholders": description_placeholders or {},
+        }
+
+    def async_create_entry(self, *, title, data):
+        return {"type": "create_entry", "title": title, "data": data}
+
+    def async_abort(self, *, reason):
+        return {"type": "abort", "reason": reason}
+
+    def async_update_reload_and_abort(self, entry, *, data):
+        return {"type": "abort", "reason": "reauth_successful"}
+
+
 ha_config_entries = _make_module(
     "homeassistant.config_entries",
     ConfigEntry=_ConfigEntry,
-    ConfigFlow=MagicMock,
+    ConfigFlow=_ConfigFlowBase,
+    SOURCE_IGNORE="ignore",
 )
 ha_const = _make_module(
     "homeassistant.const",

--- a/tests/test_standalone_oauth_flow.py
+++ b/tests/test_standalone_oauth_flow.py
@@ -1,0 +1,323 @@
+"""Unit tests for the standalone SmartThings OAuth config flow path."""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# conftest installs HA stubs before any component imports
+from tests.conftest import _HomeAssistant
+
+from custom_components.samsung_familyhub_fridge.const import (
+    AUTH_MODE_STANDALONE_OAUTH,
+    CONF_AUTH_MODE,
+    CONF_OAUTH_CLIENT_ID,
+    CONF_OAUTH_CLIENT_SECRET,
+    CONF_OAUTH_REFRESH_TOKEN,
+    CONF_SAMSUNG_IOT_AUTH_SERVER,
+    CONF_SAMSUNG_IOT_REFRESH_TOKEN,
+)
+from custom_components.samsung_familyhub_fridge.config_flow import ConfigFlow
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_flow(hass) -> ConfigFlow:
+    """Return a ConfigFlow instance wired to a stub hass."""
+    flow = ConfigFlow()
+    flow.hass = hass
+    return flow
+
+
+def _fake_oauth_creds(access="tok-access", refresh="tok-refresh"):
+    creds = MagicMock()
+    creds.access_token = access
+    creds.refresh_token = refresh
+    return creds
+
+
+def _fake_iot_creds(refresh="iot-refresh", auth_server="https://us-auth2.samsungosp.com"):
+    creds = MagicMock()
+    creds.refresh_token = refresh
+    creds.auth_server_url = auth_server
+    return creds
+
+
+# ---------------------------------------------------------------------------
+# async_step_user — menu wiring
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_step_user_no_smartthings_entries_shows_standalone_and_pat():
+    hass = _HomeAssistant()
+    hass.config_entries = MagicMock()
+    hass.config_entries.async_entries = MagicMock(return_value=[])
+
+    flow = _make_flow(hass)
+    result = await flow.async_step_user()
+
+    assert result["type"] == "menu" or "menu_options" in result
+    assert "standalone_oauth" in result["menu_options"]
+    assert "pat" in result["menu_options"]
+
+
+@pytest.mark.asyncio
+async def test_step_user_with_smartthings_entries_shows_all_three():
+    hass = _HomeAssistant()
+    entry = MagicMock()
+    entry.source = "user"
+    hass.config_entries = MagicMock()
+    hass.config_entries.async_entries = MagicMock(return_value=[entry])
+
+    flow = _make_flow(hass)
+    result = await flow.async_step_user()
+
+    options = result["menu_options"]
+    assert "oauth" in options
+    assert "standalone_oauth" in options
+    assert "pat" in options
+
+
+# ---------------------------------------------------------------------------
+# async_step_standalone_oauth_credentials
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_credentials_step_empty_shows_form():
+    hass = _HomeAssistant()
+    flow = _make_flow(hass)
+    result = await flow.async_step_standalone_oauth_credentials()
+    assert result["type"] == "form"
+    assert result["step_id"] == "standalone_oauth_credentials"
+
+
+@pytest.mark.asyncio
+async def test_credentials_step_missing_client_id_error():
+    hass = _HomeAssistant()
+    flow = _make_flow(hass)
+    result = await flow.async_step_standalone_oauth_credentials(
+        user_input={CONF_OAUTH_CLIENT_ID: "", CONF_OAUTH_CLIENT_SECRET: "secret"}
+    )
+    assert result["errors"].get(CONF_OAUTH_CLIENT_ID) == "required"
+
+
+@pytest.mark.asyncio
+async def test_credentials_step_missing_client_secret_error():
+    hass = _HomeAssistant()
+    flow = _make_flow(hass)
+    result = await flow.async_step_standalone_oauth_credentials(
+        user_input={CONF_OAUTH_CLIENT_ID: "my-client", CONF_OAUTH_CLIENT_SECRET: ""}
+    )
+    assert result["errors"].get(CONF_OAUTH_CLIENT_SECRET) == "required"
+
+
+@pytest.mark.asyncio
+async def test_credentials_step_valid_advances_to_link():
+    hass = _HomeAssistant()
+    flow = _make_flow(hass)
+
+    with patch(
+        "custom_components.samsung_familyhub_fridge.config_flow.SmartThingsOAuth"
+    ) as MockOAuth:
+        mock_oauth = MagicMock()
+        mock_oauth.get_authorization_url.return_value = "https://auth.smartthings.com/authorize?code_challenge=xyz"
+        MockOAuth.return_value = mock_oauth
+
+        result = await flow.async_step_standalone_oauth_credentials(
+            user_input={
+                CONF_OAUTH_CLIENT_ID: "my-client",
+                CONF_OAUTH_CLIENT_SECRET: "my-secret",
+            }
+        )
+
+    assert result["step_id"] == "standalone_oauth_link"
+    assert flow._standalone_client_id == "my-client"
+    assert flow._standalone_client_secret == "my-secret"
+    assert flow._standalone_oauth is mock_oauth
+
+
+# ---------------------------------------------------------------------------
+# async_step_standalone_oauth_link
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_link_step_shows_form_with_auth_url():
+    hass = _HomeAssistant()
+    flow = _make_flow(hass)
+    oauth = MagicMock()
+    oauth.get_authorization_url.return_value = "https://auth.example.com/go"
+    flow._standalone_oauth = oauth
+    flow._standalone_auth_url = "https://auth.example.com/go"
+
+    result = await flow.async_step_standalone_oauth_link()
+
+    assert result["step_id"] == "standalone_oauth_link"
+    assert result["description_placeholders"]["authorization_url"] == "https://auth.example.com/go"
+
+
+@pytest.mark.asyncio
+async def test_link_step_empty_input_error():
+    hass = _HomeAssistant()
+    flow = _make_flow(hass)
+    oauth = MagicMock()
+    oauth.get_authorization_url.return_value = "https://auth.example.com/go"
+    flow._standalone_oauth = oauth
+    flow._standalone_auth_url = "https://auth.example.com/go"
+
+    result = await flow.async_step_standalone_oauth_link(
+        user_input={"redirect_url_or_code": ""}
+    )
+    assert result["errors"]["redirect_url_or_code"] == "required"
+
+
+@pytest.mark.asyncio
+async def test_link_step_invalid_redirect_url_error():
+    hass = _HomeAssistant()
+    flow = _make_flow(hass)
+
+    with patch(
+        "custom_components.samsung_familyhub_fridge.config_flow.SmartThingsOAuth"
+    ) as MockOAuth:
+        MockOAuth.extract_code_from_redirect.side_effect = ValueError("no code")
+        oauth = MagicMock()
+        oauth.get_authorization_url.return_value = "https://auth.example.com/go"
+        flow._standalone_oauth = oauth
+        flow._standalone_auth_url = "https://auth.example.com/go"
+
+        result = await flow.async_step_standalone_oauth_link(
+            user_input={"redirect_url_or_code": "https://httpbin.org/get?no_code=1"}
+        )
+    assert result["errors"]["redirect_url_or_code"] == "invalid_redirect_url"
+
+
+@pytest.mark.asyncio
+async def test_link_step_raw_code_advances():
+    hass = _HomeAssistant()
+    flow = _make_flow(hass)
+    oauth_mock = MagicMock()
+    oauth_mock.get_authorization_url.return_value = "https://auth.example.com/go"
+    oauth_mock.exchange_code.return_value = _fake_oauth_creds()
+    flow._standalone_oauth = oauth_mock
+    flow._standalone_auth_url = "https://auth.example.com/go"
+
+    result = await flow.async_step_standalone_oauth_link(
+        user_input={"redirect_url_or_code": "raw-auth-code-abc"}
+    )
+
+    assert result["step_id"] == "standalone_oauth_samsung"
+    assert flow._standalone_refresh_token == "tok-refresh"
+
+
+@pytest.mark.asyncio
+async def test_link_step_full_redirect_url_advances():
+    hass = _HomeAssistant()
+    flow = _make_flow(hass)
+
+    with patch(
+        "custom_components.samsung_familyhub_fridge.config_flow.SmartThingsOAuth"
+    ) as MockOAuth:
+        MockOAuth.extract_code_from_redirect.return_value = "extracted-code"
+        oauth_mock = MagicMock()
+        oauth_mock.get_authorization_url.return_value = "https://auth.example.com/go"
+        oauth_mock.exchange_code.return_value = _fake_oauth_creds()
+        flow._standalone_oauth = oauth_mock
+        flow._standalone_auth_url = "https://auth.example.com/go"
+
+        result = await flow.async_step_standalone_oauth_link(
+            user_input={"redirect_url_or_code": "https://httpbin.org/get?code=extracted-code"}
+        )
+
+    assert result["step_id"] == "standalone_oauth_samsung"
+
+
+# ---------------------------------------------------------------------------
+# async_step_standalone_oauth_samsung
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_samsung_step_shows_form_on_first_call():
+    hass = _HomeAssistant()
+    flow = _make_flow(hass)
+    flow._standalone_client_id = "cid"
+    flow._standalone_client_secret = "csec"
+    flow._standalone_refresh_token = "rt"
+
+    result = await flow.async_step_standalone_oauth_samsung()
+
+    assert result["step_id"] == "standalone_oauth_samsung"
+    assert result["type"] == "form"
+
+
+@pytest.mark.asyncio
+async def test_samsung_step_skip_creates_entry_without_iot():
+    hass = _HomeAssistant()
+    flow = _make_flow(hass)
+    flow._standalone_client_id = "cid"
+    flow._standalone_client_secret = "csec"
+    flow._standalone_refresh_token = "rt"
+    created_entries = []
+    flow.async_create_entry = lambda title, data: {"type": "create_entry", "title": title, "data": data}
+
+    result = await flow.async_step_standalone_oauth_samsung(
+        user_input={"samsung_email": "", "samsung_password": ""}
+    )
+
+    assert result["type"] == "create_entry"
+    assert result["data"][CONF_AUTH_MODE] == AUTH_MODE_STANDALONE_OAUTH
+    assert result["data"][CONF_OAUTH_CLIENT_ID] == "cid"
+    assert result["data"][CONF_OAUTH_REFRESH_TOKEN] == "rt"
+    assert CONF_SAMSUNG_IOT_REFRESH_TOKEN not in result["data"]
+
+
+@pytest.mark.asyncio
+async def test_samsung_step_with_credentials_creates_entry_with_iot():
+    hass = _HomeAssistant()
+    flow = _make_flow(hass)
+    flow._standalone_client_id = "cid"
+    flow._standalone_client_secret = "csec"
+    flow._standalone_refresh_token = "rt"
+    flow.async_create_entry = lambda title, data: {"type": "create_entry", "title": title, "data": data}
+
+    with patch(
+        "custom_components.samsung_familyhub_fridge.config_flow.SamsungAccountAuth"
+    ) as MockSamsungAuth:
+        mock_auth = MagicMock()
+        mock_auth.login_iot.return_value = _fake_iot_creds()
+        MockSamsungAuth.return_value = mock_auth
+
+        result = await flow.async_step_standalone_oauth_samsung(
+            user_input={"samsung_email": "user@example.com", "samsung_password": "pass"}
+        )
+
+    assert result["type"] == "create_entry"
+    data = result["data"]
+    assert data[CONF_AUTH_MODE] == AUTH_MODE_STANDALONE_OAUTH
+    assert data[CONF_SAMSUNG_IOT_REFRESH_TOKEN] == "iot-refresh"
+    assert data[CONF_SAMSUNG_IOT_AUTH_SERVER] == "https://us-auth2.samsungosp.com"
+
+
+@pytest.mark.asyncio
+async def test_samsung_step_login_failure_shows_error():
+    from custom_components.samsung_familyhub_fridge.auth import AuthError
+
+    hass = _HomeAssistant()
+    flow = _make_flow(hass)
+    flow._standalone_client_id = "cid"
+    flow._standalone_client_secret = "csec"
+    flow._standalone_refresh_token = "rt"
+
+    with patch(
+        "custom_components.samsung_familyhub_fridge.config_flow.SamsungAccountAuth"
+    ) as MockSamsungAuth:
+        mock_auth = MagicMock()
+        mock_auth.login_iot.side_effect = AuthError("bad credentials")
+        MockSamsungAuth.return_value = mock_auth
+
+        result = await flow.async_step_standalone_oauth_samsung(
+            user_input={"samsung_email": "user@example.com", "samsung_password": "wrong"}
+        )
+
+    assert result["errors"]["base"] == "samsung_login_failed"
+    assert result["step_id"] == "standalone_oauth_samsung"

--- a/tests/test_standalone_oauth_integration.py
+++ b/tests/test_standalone_oauth_integration.py
@@ -1,0 +1,195 @@
+"""Integration tests for the standalone SmartThings OAuth config flow.
+
+These tests drive the full 3-step flow through the real config_flow module
+without mocking the flow's internal logic — only external network calls are
+stubbed (requests_mock / MagicMock).
+
+Run with:
+    pytest tests/test_standalone_oauth_integration.py -v
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests_mock as rm
+
+from tests.conftest import _HomeAssistant
+
+from custom_components.samsung_familyhub_fridge.config_flow import ConfigFlow
+from custom_components.samsung_familyhub_fridge.const import (
+    AUTH_MODE_STANDALONE_OAUTH,
+    CONF_AUTH_MODE,
+    CONF_OAUTH_CLIENT_ID,
+    CONF_OAUTH_CLIENT_SECRET,
+    CONF_OAUTH_REFRESH_TOKEN,
+    CONF_SAMSUNG_IOT_AUTH_SERVER,
+    CONF_SAMSUNG_IOT_REFRESH_TOKEN,
+)
+from custom_components.samsung_familyhub_fridge.auth import (
+    TOKEN_URL,
+    SAMSUNG_AUTH_URL,
+    SAMSUNG_IOT_AUTHORIZE_URL,
+    SAMSUNG_IOT_TOKEN_URL,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_flow(hass) -> ConfigFlow:
+    flow = ConfigFlow()
+    flow.hass = hass
+    return flow
+
+
+# ---------------------------------------------------------------------------
+# Full happy-path: credentials → link (raw code) → samsung (skipped)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_full_flow_raw_code_skip_samsung(requests_mock):
+    """End-to-end: enter credentials, exchange raw code, skip Samsung login."""
+    hass = _HomeAssistant()
+    hass.config_entries = MagicMock()
+    hass.config_entries.async_entries = MagicMock(return_value=[])
+
+    flow = _make_flow(hass)
+
+    # Step 1 — menu
+    result = await flow.async_step_user()
+    assert "standalone_oauth" in result["menu_options"]
+
+    # Step 2 — credentials
+    result = await flow.async_step_standalone_oauth_credentials(
+        user_input={
+            CONF_OAUTH_CLIENT_ID: "integ-client-id",
+            CONF_OAUTH_CLIENT_SECRET: "integ-client-secret",
+        }
+    )
+    assert result["step_id"] == "standalone_oauth_link", f"Expected link step, got: {result}"
+
+    # Stub the token exchange endpoint
+    requests_mock.post(
+        TOKEN_URL,
+        json={
+            "access_token": "integ-access-token",
+            "refresh_token": "integ-refresh-token",
+            "token_type": "bearer",
+            "expires_in": 86400,
+        },
+    )
+
+    # Step 3 — link (raw auth code)
+    result = await flow.async_step_standalone_oauth_link(
+        user_input={"redirect_url_or_code": "raw-code-xyz"}
+    )
+    assert result["step_id"] == "standalone_oauth_samsung", f"Expected samsung step, got: {result}"
+    assert flow._standalone_refresh_token == "integ-refresh-token"
+
+    # Step 4 — samsung (skip by sending empty credentials)
+    result = await flow.async_step_standalone_oauth_samsung(
+        user_input={"samsung_email": "", "samsung_password": ""}
+    )
+    assert result["type"] == "create_entry"
+    data = result["data"]
+    assert data[CONF_AUTH_MODE] == AUTH_MODE_STANDALONE_OAUTH
+    assert data[CONF_OAUTH_CLIENT_ID] == "integ-client-id"
+    assert data[CONF_OAUTH_CLIENT_SECRET] == "integ-client-secret"
+    assert data[CONF_OAUTH_REFRESH_TOKEN] == "integ-refresh-token"
+    assert CONF_SAMSUNG_IOT_REFRESH_TOKEN not in data
+
+
+# ---------------------------------------------------------------------------
+# Full happy-path: credentials → link (redirect URL) → samsung login
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_full_flow_redirect_url_with_samsung(requests_mock):
+    """End-to-end: enter credentials, exchange via redirect URL, Samsung login."""
+    hass = _HomeAssistant()
+    hass.config_entries = MagicMock()
+    hass.config_entries.async_entries = MagicMock(return_value=[])
+
+    flow = _make_flow(hass)
+
+    # Step 2 — credentials
+    result = await flow.async_step_standalone_oauth_credentials(
+        user_input={
+            CONF_OAUTH_CLIENT_ID: "integ-client-id",
+            CONF_OAUTH_CLIENT_SECRET: "integ-client-secret",
+        }
+    )
+
+    # Stub token exchange
+    requests_mock.post(
+        TOKEN_URL,
+        json={
+            "access_token": "integ-access-token",
+            "refresh_token": "integ-refresh-token",
+            "token_type": "bearer",
+            "expires_in": 86400,
+        },
+    )
+
+    # Step 3 — link via redirect URL
+    redirect_url = "https://httpbin.org/get?code=redirect-code-abc&state=xyz"
+    result = await flow.async_step_standalone_oauth_link(
+        user_input={"redirect_url_or_code": redirect_url}
+    )
+    assert result["step_id"] == "standalone_oauth_samsung"
+
+    # Stub Samsung Account login → IoT token flow
+    requests_mock.post(
+        SAMSUNG_AUTH_URL,
+        json={"userauth_token": "samsung-userauth-tok"},
+    )
+    requests_mock.get(
+        SAMSUNG_IOT_AUTHORIZE_URL,
+        json={"code": "iot-auth-code"},
+        headers={"Content-Type": "application/json"},
+        status_code=200,
+    )
+    requests_mock.post(
+        SAMSUNG_IOT_TOKEN_URL,
+        json={
+            "access_token": "iot-access-token",
+            "refresh_token": "iot-refresh-token",
+        },
+    )
+
+    # Step 4 — Samsung Account credentials provided
+    result = await flow.async_step_standalone_oauth_samsung(
+        user_input={
+            "samsung_email": "user@example.com",
+            "samsung_password": "test-password",
+        }
+    )
+
+    assert result["type"] == "create_entry"
+    data = result["data"]
+    assert data[CONF_AUTH_MODE] == AUTH_MODE_STANDALONE_OAUTH
+    assert data[CONF_OAUTH_REFRESH_TOKEN] == "integ-refresh-token"
+    assert data[CONF_SAMSUNG_IOT_REFRESH_TOKEN] == "iot-refresh-token"
+    assert data[CONF_SAMSUNG_IOT_AUTH_SERVER] == "https://us-auth2.samsungosp.com"
+
+
+# ---------------------------------------------------------------------------
+# Error path: invalid redirect URL shows a clear error
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_invalid_redirect_url_shows_error():
+    """Link step: URL with no 'code' param shows invalid_redirect_url error."""
+    hass = _HomeAssistant()
+    flow = _make_flow(hass)
+    flow._standalone_auth_url = "https://api.smartthings.com/oauth/authorize?test=1"
+    flow._standalone_oauth = MagicMock()
+    flow._standalone_oauth.get_authorization_url.return_value = "https://api.smartthings.com/oauth/authorize"
+
+    result = await flow.async_step_standalone_oauth_link(
+        user_input={"redirect_url_or_code": "https://httpbin.org/get?no_code_here=1"}
+    )
+    assert result["step_id"] == "standalone_oauth_link"
+    assert result["errors"]["redirect_url_or_code"] == "invalid_redirect_url"


### PR DESCRIPTION
[Tindómiel Web-Smith] — sme-scrum-6

## Task
SCRUM-6 — Standalone SmartThings OAuth: config flow UI

## Summary
Adds a standalone SmartThings OAuth config flow path so users with a custom SmartThings app (client_id + client_secret) can authenticate directly without needing the HA Core SmartThings integration. The flow consists of three steps: enter app credentials, authorize in browser and paste the redirect URL or raw code, and optionally provide Samsung Account credentials for IoT camera features.

## What changed
- `const.py`: Added `AUTH_MODE_STANDALONE_OAUTH = 'standalone_oauth'`, `CONF_OAUTH_CLIENT_ID`, `CONF_OAUTH_CLIENT_SECRET`, `CONF_OAUTH_REFRESH_TOKEN`
- `config_flow.py`:
  - `async_step_standalone_oauth` — bridge method (HA resolves menu option `standalone_oauth` to this)
  - `async_step_standalone_oauth_credentials` — collects client_id / client_secret; validates non-empty; generates PKCE auth URL; stores in flow state
  - `async_step_standalone_oauth_link` — displays auth URL via description placeholder; accepts full redirect URL (parses code) or raw code; calls `exchange_code`; captures tokens
  - `async_step_standalone_oauth_samsung` — optional Samsung Account login via `SamsungAccountAuth.login_iot()`; skipping creates entry without IoT tokens
  - `async_step_user` — wired `standalone_oauth` into menu (all 3 options when core SmartThings entry exists; standalone + PAT when it doesn't)
- `strings.json` + `translations/en.json`: full English translations for all 3 new steps and 4 new error keys (`required`, `invalid_redirect_url`, `code_exchange_failed`, `samsung_login_failed`)
- `tests/conftest.py`: upgraded `ConfigFlow` stub from `MagicMock` to `_ConfigFlowBase` with proper `__init_subclass__` support (also fixes 3 pre-existing test failures in `test_auth_refresh.py`)
- `tests/test_standalone_oauth_flow.py`: 15 unit tests covering all acceptance criteria
- `tests/test_standalone_oauth_integration.py`: 3 integration tests driving the full 3-step flow end-to-end with stubbed HTTP

## Unit testing
```
$ python3 -m pytest tests/test_standalone_oauth_flow.py -v
...
15 passed in 0.03s
```

## Integration testing (required)
Tests drive the full config flow through real module code (only network calls are stubbed via `requests_mock`), exercising:
1. Full flow: credentials → link (raw code) → skip Samsung → `create_entry` with correct keys
2. Full flow: credentials → link (redirect URL) → Samsung login via stubbed HTTP → `create_entry` with IoT tokens
3. Error path: redirect URL with no `code` param → `invalid_redirect_url` error on link step

```
$ python3 -m pytest tests/test_standalone_oauth_integration.py -v
tests/test_standalone_oauth_integration.py::test_full_flow_raw_code_skip_samsung PASSED
tests/test_standalone_oauth_integration.py::test_full_flow_redirect_url_with_samsung PASSED
tests/test_standalone_oauth_integration.py::test_invalid_redirect_url_shows_error PASSED

3 passed in 0.03s
```

Full suite (excluding live-API integration tests):
```
$ python3 -m pytest tests/ --ignore=tests/test_integration.py
76 passed in 0.64s
```

## Risks / follow-ups
- `_get_reauth_entry()` is not yet wired for `standalone_oauth` mode reauth (reauth for standalone OAuth would require re-entering credentials or the new refresh token; deferred as a follow-up)
- The Samsung Account headless login (`SamsungAccountAuth`) does not support accounts with 2FA enabled — the step description makes this clear