### PR TITLE
SCRUM-9: Standalone SmartThings OAuth runtime token refresh & setup

### DIFF
--- a/custom_components/samsung_familyhub_fridge/__init__.py
+++ b/custom_components/samsung_familyhub_fridge/__init__.py
@@ -2,14 +2,22 @@
 
 Auth modes (data["auth_mode"]):
 
-- "oauth"  : Reuse the HA core `smartthings` integration's OAuth2 credentials.
-             Tokens refresh automatically via HA's OAuth2Session — no manual
-             PAT rotation. Requires a working `smartthings` config entry
-             referenced by `data["linked_smartthings_entry_id"]`.
+- "oauth"           : Reuse the HA core `smartthings` integration's OAuth2
+                      credentials. Tokens refresh automatically via
+                      HA's OAuth2Session — no manual PAT rotation. Requires
+                      a working `smartthings` config entry referenced by
+                      `data["linked_smartthings_entry_id"]`.
 
-- "pat"    : Legacy SmartThings Personal Access Token (raw string). Samsung
-             deprecated indefinite PATs on 2024-12-30 — new PATs expire after
-             24 hours. Retained for backwards compatibility only.
+- "pat"             : Legacy SmartThings Personal Access Token (raw string).
+                      Samsung deprecated indefinite PATs on 2024-12-30 —
+                      new PATs expire after 24 hours. Retained for backwards
+                      compatibility only.
+
+- "standalone_oauth": Custom SmartThings app credentials (client_id +
+                      client_secret + refresh_token). Access token refreshed
+                      from stored refresh token at startup and before each
+                      poll when within 5 minutes of expiry. No HA core
+                      SmartThings integration needed.
 
 Config entries created before this integration version stored `{token, device_id}`
 without an `auth_mode` key; they are migrated to `auth_mode: "pat"` on first
@@ -18,6 +26,7 @@ load via `async_migrate_entry`.
 from __future__ import annotations
 
 import logging
+import time
 from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
@@ -30,9 +39,13 @@ from .api import FamilyHub
 from .const import (
     AUTH_MODE_OAUTH,
     AUTH_MODE_PAT,
+    AUTH_MODE_STANDALONE_OAUTH,
     CONF_AUTH_MODE,
     CONF_DEVICE_ID,
     CONF_LINKED_SMARTTHINGS_ENTRY_ID,
+    CONF_OAUTH_CLIENT_ID,
+    CONF_OAUTH_CLIENT_SECRET,
+    CONF_OAUTH_REFRESH_TOKEN,
     CONF_SAMSUNG_IOT_AUTH_SERVER,
     CONF_SAMSUNG_IOT_REFRESH_TOKEN,
     CONF_TOKEN,
@@ -54,6 +67,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     if auth_mode == AUTH_MODE_OAUTH:
         hub = await _build_oauth_hub(hass, entry, device_id)
+    elif auth_mode == AUTH_MODE_STANDALONE_OAUTH:
+        hub = await _build_standalone_oauth_hub(hass, entry, device_id)
     else:
         # Legacy PAT path — unchanged from v0.0.x.
         token = entry.data.get(CONF_TOKEN)
@@ -157,6 +172,79 @@ async def _build_oauth_hub(
     return hub
 
 
+async def _build_standalone_oauth_hub(
+    hass: HomeAssistant, entry: ConfigEntry, device_id: str | None
+) -> FamilyHub:
+    """Construct a FamilyHub using custom SmartThings app OAuth credentials.
+
+    Refreshes the stored refresh token at startup and wires up per-poll
+    proactive refresh (5-minute window). Samsung IoT token is also refreshed
+    at startup if present.
+
+    Raises ConfigEntryNotReady if the initial token refresh fails.
+    """
+    from .auth import SmartThingsOAuth, refresh_samsung_iot_token
+
+    client_id = entry.data.get(CONF_OAUTH_CLIENT_ID)
+    client_secret = entry.data.get(CONF_OAUTH_CLIENT_SECRET)
+    stored_refresh = entry.data.get(CONF_OAUTH_REFRESH_TOKEN)
+
+    if not client_id or not client_secret or not stored_refresh:
+        raise ConfigEntryNotReady(
+            "standalone_oauth config entry is missing oauth_client_id, "
+            "oauth_client_secret, or oauth_refresh_token. Reconfigure the "
+            "integration in Settings → Devices & Services."
+        )
+
+    oauth = SmartThingsOAuth(client_id=client_id, client_secret=client_secret)
+
+    try:
+        creds = await hass.async_add_executor_job(oauth.refresh, stored_refresh)
+    except Exception as err:
+        raise ConfigEntryNotReady(
+            f"Failed to refresh standalone OAuth access token at startup: {err}"
+        ) from err
+
+    # Persist the new refresh token (it rotates on every use).
+    updated_data: dict[str, Any] = {
+        **entry.data,
+        CONF_OAUTH_REFRESH_TOKEN: creds.refresh_token,
+    }
+
+    hub = FamilyHub(hass, token=creds.access_token, device_id=device_id)
+    expires_at = time.time() + (creds.expires_in or 86400)
+    hub.attach_standalone_oauth(
+        oauth,
+        expires_at,
+        refresh_token=creds.refresh_token,
+        config_entry=entry,
+    )
+
+    # Optionally refresh Samsung IoT token for image downloads.
+    iot_refresh = entry.data.get(CONF_SAMSUNG_IOT_REFRESH_TOKEN)
+    iot_server = entry.data.get(
+        CONF_SAMSUNG_IOT_AUTH_SERVER, "https://us-auth2.samsungosp.com"
+    )
+    if iot_refresh:
+        try:
+            iot_creds = await hass.async_add_executor_job(
+                refresh_samsung_iot_token, iot_refresh, iot_server
+            )
+            hub.set_samsung_iot_token(iot_creds.access_token)
+            if iot_creds.refresh_token != iot_refresh:
+                updated_data[CONF_SAMSUNG_IOT_REFRESH_TOKEN] = iot_creds.refresh_token
+            _LOGGER.info("Samsung IoT token refreshed for image downloads")
+        except Exception as err:  # pylint: disable=broad-except
+            _LOGGER.warning(
+                "Could not refresh Samsung IoT token — image downloads "
+                "will fail until resolved: %s",
+                err,
+            )
+
+    hass.config_entries.async_update_entry(entry, data=updated_data)
+    return hub
+
+
 async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """Handle config entry updates (e.g. after re-authentication)."""
     hub: FamilyHub = hass.data[DOMAIN]["hub"]
@@ -165,7 +253,7 @@ async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> Non
         new_token = entry.data.get(CONF_TOKEN)
         if new_token:
             hub.update_token(new_token)
-    # OAuth mode refreshes its token automatically — nothing to do here.
+    # OAuth and standalone_oauth modes refresh tokens automatically.
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -186,7 +274,9 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Migrate config entry data to the current schema.
 
     v1  → {token, device_id}                     (raw PAT)
-    v2  → adds auth_mode=(pat|oauth), optional linked_smartthings_entry_id
+    v2  → adds auth_mode=(pat|oauth|standalone_oauth),
+           optional linked_smartthings_entry_id,
+           optional oauth_client_id / oauth_client_secret / oauth_refresh_token
     """
     if entry.version == 1:
         new_data: dict[str, Any] = {**entry.data, CONF_AUTH_MODE: AUTH_MODE_PAT}
@@ -196,4 +286,5 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             "Reconfigure in UI to switch to OAuth.",
             entry.entry_id,
         )
+    # v2 with auth_mode=standalone_oauth is already the correct schema — no-op.
     return True

--- a/custom_components/samsung_familyhub_fridge/api.py
+++ b/custom_components/samsung_familyhub_fridge/api.py
@@ -12,10 +12,11 @@ import requests
 
 from homeassistant.core import HomeAssistant
 
-from .const import CID, DEFAULT_TIMEOUT
+from .const import CID, CONF_OAUTH_REFRESH_TOKEN, DEFAULT_TIMEOUT
 
 if TYPE_CHECKING:
     from homeassistant.helpers import config_entry_oauth2_flow
+    from .auth import SmartThingsOAuth
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -123,6 +124,11 @@ class FamilyHub:
         # Only set in OAuth mode; PAT tokens already carry Samsung ID.
         self._samsung_iot_token: str | None = None
         self._samsung_iot_headers: dict | None = None
+        # Standalone OAuth: set via attach_standalone_oauth() for per-poll refresh.
+        self._standalone_oauth: "SmartThingsOAuth | None" = None
+        self._token_expires_at: float = 0.0
+        self._stored_refresh_token: str = ""
+        self._config_entry = None
 
     def set_samsung_iot_token(self, token: str) -> None:
         """Set a Samsung IoT token for client.smartthings.com image downloads.
@@ -146,19 +152,66 @@ class FamilyHub:
         """
         self._oauth_session = session
 
-    async def async_ensure_fresh_token(self) -> None:
-        """If running in OAuth mode, ensure the bearer token is still valid.
+    def attach_standalone_oauth(
+        self,
+        oauth: "SmartThingsOAuth",
+        expires_at: float,
+        refresh_token: str = "",
+        config_entry=None,
+    ) -> None:
+        """Attach a SmartThingsOAuth instance for per-poll token refresh.
 
-        No-op for PAT mode. Safe to call on every poll — HA's OAuth2Session
-        only performs a network refresh when the access_token is within
-        a few seconds of expiring.
+        Once attached, `async_ensure_fresh_token()` will call
+        `oauth.refresh()` whenever the token is within 5 minutes of expiry,
+        update the bearer header, and persist the new refresh token.
         """
-        if self._oauth_session is None:
+        self._standalone_oauth = oauth
+        self._token_expires_at = expires_at
+        self._stored_refresh_token = refresh_token
+        self._config_entry = config_entry
+
+    async def async_ensure_fresh_token(self) -> None:
+        """Ensure the bearer token is still valid before an API call.
+
+        Handles three auth modes:
+        - PAT mode: no-op (tokens are refreshed externally via update_token).
+        - OAuth mode (HA-linked): delegates to OAuth2Session; refreshes
+          automatically when the HA access_token is near expiry.
+        - Standalone OAuth: calls SmartThingsOAuth.refresh() when the stored
+          token is within 5 minutes of expiry; persists the new refresh token
+          to the config entry; raises ConfigEntryAuthFailed if the refresh
+          token is rejected (HTTP 401).
+        """
+        if self._oauth_session is not None:
+            await self._oauth_session.async_ensure_token_valid()
+            new_token = self._oauth_session.token.get("access_token")
+            if new_token and new_token != self.token:
+                self.update_token(new_token)
             return
-        await self._oauth_session.async_ensure_token_valid()
-        new_token = self._oauth_session.token.get("access_token")
-        if new_token and new_token != self.token:
-            self.update_token(new_token)
+
+        if self._standalone_oauth is not None and time.time() > self._token_expires_at - 300:
+            try:
+                creds = await self._hass.async_add_executor_job(
+                    self._standalone_oauth.refresh, self._stored_refresh_token
+                )
+            except requests.exceptions.HTTPError as err:
+                if err.response is not None and err.response.status_code == 401:
+                    raise ConfigEntryAuthFailed(
+                        "Standalone OAuth refresh token rejected — re-authentication required"
+                    ) from err
+                raise
+            self.update_token(creds.access_token)
+            self._stored_refresh_token = creds.refresh_token
+            self._token_expires_at = time.time() + (creds.expires_in or 86400)
+            if self._config_entry is not None:
+                new_data = {
+                    **self._config_entry.data,
+                    CONF_OAUTH_REFRESH_TOKEN: creds.refresh_token,
+                }
+                self._hass.config_entries.async_update_entry(
+                    self._config_entry, data=new_data
+                )
+            _LOGGER.debug("Standalone OAuth access token refreshed")
 
     def update_token(self, token: str) -> None:
         """Update the API token (used after re-authentication or OAuth refresh)."""

--- a/custom_components/samsung_familyhub_fridge/config_flow.py
+++ b/custom_components/samsung_familyhub_fridge/config_flow.py
@@ -338,11 +338,29 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self, entry_data: dict[str, Any]
     ) -> FlowResult:
         """Handle re-authentication when the token has expired."""
+        auth_mode = entry_data.get(CONF_AUTH_MODE)
+
+        if auth_mode == AUTH_MODE_STANDALONE_OAUTH:
+            # Re-run the link step if we still have valid client credentials;
+            # otherwise restart from the credentials step.
+            client_id = entry_data.get(CONF_OAUTH_CLIENT_ID, "").strip()
+            client_secret = entry_data.get(CONF_OAUTH_CLIENT_SECRET, "").strip()
+            if client_id and client_secret:
+                oauth = SmartThingsOAuth(
+                    client_id=client_id, client_secret=client_secret
+                )
+                self._standalone_oauth = oauth
+                self._standalone_client_id = client_id
+                self._standalone_client_secret = client_secret
+                self._standalone_auth_url = oauth.get_authorization_url()
+                return await self.async_step_standalone_oauth_link()
+            return await self.async_step_standalone_oauth_credentials()
+
         # OAuth-mode entries should never reach reauth: HA's OAuth2Session
         # refreshes transparently and any hard failure is surfaced on the
         # linked smartthings entry itself. If we do land here, offer both
         # paths again so the user can re-link.
-        if entry_data.get(CONF_AUTH_MODE) == AUTH_MODE_OAUTH:
+        if auth_mode == AUTH_MODE_OAUTH:
             return await self.async_step_user()
         return await self.async_step_reauth_confirm()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -63,6 +63,25 @@ def pytest_addoption(parser):
         default=None,
         help="Samsung OAuth signin_client_secret (from SmartThings APK)",
     )
+    # --- Standalone OAuth runtime integration tests ---
+    parser.addoption(
+        "--standalone-oauth-client-id",
+        action="store",
+        default=None,
+        help="SmartThings app client_id for standalone OAuth runtime tests",
+    )
+    parser.addoption(
+        "--standalone-oauth-client-secret",
+        action="store",
+        default=None,
+        help="SmartThings app client_secret for standalone OAuth runtime tests",
+    )
+    parser.addoption(
+        "--standalone-oauth-refresh-token",
+        action="store",
+        default=None,
+        help="SmartThings refresh token for standalone OAuth runtime tests",
+    )
 
 
 @pytest.fixture
@@ -175,12 +194,38 @@ class _ServiceCall:
         self.data = data or {}
 
 
+class _ConfigEntriesManager:
+    """Minimal stub of hass.config_entries used in unit tests."""
+
+    def __init__(self):
+        self._entries = {}
+
+    def async_update_entry(self, entry, *, data=None, version=None, **kwargs):
+        if data is not None:
+            entry.data = data
+        if version is not None:
+            entry.version = version
+
+    def async_get_entry(self, entry_id):
+        return self._entries.get(entry_id)
+
+    def async_entries(self, domain=None):
+        return []
+
+    async def async_forward_entry_setups(self, entry, platforms):
+        return True
+
+    async def async_unload_platforms(self, entry, platforms):
+        return True
+
+
 class _HomeAssistant:
     """Minimal stub of homeassistant.core.HomeAssistant."""
 
     def __init__(self):
         self.async_add_executor_job = AsyncMock(side_effect=self._run_sync)
         self.services = _ServiceRegistry()
+        self.config_entries = _ConfigEntriesManager()
 
     async def _run_sync(self, func, *args):
         return func(*args)
@@ -436,3 +481,28 @@ except ImportError:
     vol.Required = lambda *a, **kw: a[0] if a else "required"
     vol.Optional = lambda *a, **kw: a[0] if a else "optional"
     sys.modules["voluptuous"] = vol
+
+
+@pytest.fixture
+def standalone_oauth_credentials(request):
+    """Provide standalone OAuth credentials; auto-skip without them.
+
+    Pass via CLI:
+        --standalone-oauth-client-id CID
+        --standalone-oauth-client-secret SECRET
+        --standalone-oauth-refresh-token REFRESH
+    """
+    client_id = request.config.getoption("--standalone-oauth-client-id")
+    client_secret = request.config.getoption("--standalone-oauth-client-secret")
+    refresh_token = request.config.getoption("--standalone-oauth-refresh-token")
+    if not (client_id and client_secret and refresh_token):
+        pytest.skip(
+            "Standalone OAuth credentials not provided — "
+            "pass --standalone-oauth-client-id, --standalone-oauth-client-secret, "
+            "and --standalone-oauth-refresh-token to run these tests"
+        )
+    return {
+        "client_id": client_id,
+        "client_secret": client_secret,
+        "refresh_token": refresh_token,
+    }

--- a/tests/test_standalone_oauth_integration.py
+++ b/tests/test_standalone_oauth_integration.py
@@ -1,8 +1,15 @@
-"""Integration tests for the standalone SmartThings OAuth config flow.
+"""Integration tests for the standalone SmartThings OAuth config flow and runtime.
 
-These tests drive the full 3-step flow through the real config_flow module
-without mocking the flow's internal logic — only external network calls are
-stubbed (requests_mock / MagicMock).
+Part 1 (config flow): drives the full 3-step flow through the real config_flow
+module without mocking the flow's internal logic — only external network calls
+are stubbed (requests_mock / MagicMock).
+
+Part 2 (runtime): real-API tests that exercise token refresh against live
+SmartThings endpoints. These auto-skip unless standalone OAuth credentials are
+passed via CLI flags:
+    --standalone-oauth-client-id CID
+    --standalone-oauth-client-secret SECRET
+    --standalone-oauth-refresh-token REFRESH
 
 Run with:
     pytest tests/test_standalone_oauth_integration.py -v
@@ -14,8 +21,11 @@ from unittest.mock import MagicMock, patch
 import pytest
 import requests_mock as rm
 
-from tests.conftest import _HomeAssistant
+import time
 
+from tests.conftest import _HomeAssistant, _ConfigEntry
+
+from custom_components.samsung_familyhub_fridge.api import FamilyHub
 from custom_components.samsung_familyhub_fridge.config_flow import ConfigFlow
 from custom_components.samsung_familyhub_fridge.const import (
     AUTH_MODE_STANDALONE_OAUTH,
@@ -31,6 +41,7 @@ from custom_components.samsung_familyhub_fridge.auth import (
     SAMSUNG_AUTH_URL,
     SAMSUNG_IOT_AUTHORIZE_URL,
     SAMSUNG_IOT_TOKEN_URL,
+    SmartThingsOAuth,
 )
 
 
@@ -193,3 +204,97 @@ async def test_invalid_redirect_url_shows_error():
     )
     assert result["step_id"] == "standalone_oauth_link"
     assert result["errors"]["redirect_url_or_code"] == "invalid_redirect_url"
+
+
+# ===========================================================================
+# Part 2 — Runtime integration tests (real SmartThings API calls)
+#
+# These tests auto-skip when standalone OAuth credentials are absent.
+# Pass via CLI:
+#   --standalone-oauth-client-id CID
+#   --standalone-oauth-client-secret SECRET
+#   --standalone-oauth-refresh-token REFRESH
+# ===========================================================================
+
+
+# ---------------------------------------------------------------------------
+# Runtime test 1: SmartThingsOAuth.refresh() returns a valid token pair
+# ---------------------------------------------------------------------------
+
+def test_real_oauth_refresh_returns_tokens(standalone_oauth_credentials):
+    """Real refresh call returns access_token and a (possibly rotated) refresh_token."""
+    creds = standalone_oauth_credentials
+    oauth = SmartThingsOAuth(
+        client_id=creds["client_id"],
+        client_secret=creds["client_secret"],
+    )
+    result = oauth.refresh(creds["refresh_token"])
+
+    assert result.access_token, "Expected a non-empty access_token"
+    assert result.refresh_token, "Expected a non-empty refresh_token"
+    assert result.expires_in > 0, "Expected a positive expires_in"
+
+
+# ---------------------------------------------------------------------------
+# Runtime test 2: FamilyHub.attach_standalone_oauth + ensure_fresh_token
+#                 refreshes the access token when near expiry
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_real_ensure_fresh_token_refreshes(standalone_oauth_credentials):
+    """attach_standalone_oauth + async_ensure_fresh_token refreshes near-expiry token."""
+    creds = standalone_oauth_credentials
+    hass = _HomeAssistant()
+    entry = _ConfigEntry(
+        data={
+            CONF_AUTH_MODE: AUTH_MODE_STANDALONE_OAUTH,
+            CONF_OAUTH_CLIENT_ID: creds["client_id"],
+            CONF_OAUTH_CLIENT_SECRET: creds["client_secret"],
+            CONF_OAUTH_REFRESH_TOKEN: creds["refresh_token"],
+        }
+    )
+    oauth = SmartThingsOAuth(
+        client_id=creds["client_id"],
+        client_secret=creds["client_secret"],
+    )
+    hub = FamilyHub(hass, token="placeholder", device_id=None)
+    # Set expires_at to now − 1 so the token is already "expired" → must refresh
+    hub.attach_standalone_oauth(
+        oauth,
+        expires_at=time.time() - 1,
+        refresh_token=creds["refresh_token"],
+        config_entry=entry,
+    )
+
+    await hub.async_ensure_fresh_token()
+
+    assert hub.token != "placeholder", "Token should have been updated after refresh"
+    assert hub._stored_refresh_token, "Refresh token should be set after refresh"
+    assert entry.data[CONF_OAUTH_REFRESH_TOKEN] == hub._stored_refresh_token
+
+
+# ---------------------------------------------------------------------------
+# Runtime test 3: FamilyHub skips refresh when token is not near expiry
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_real_ensure_fresh_token_skips_when_not_expiring(standalone_oauth_credentials):
+    """async_ensure_fresh_token does NOT call the network when token is fresh."""
+    creds = standalone_oauth_credentials
+    hass = _HomeAssistant()
+    oauth = SmartThingsOAuth(
+        client_id=creds["client_id"],
+        client_secret=creds["client_secret"],
+    )
+    hub = FamilyHub(hass, token="sentinel-token", device_id=None)
+    # Expiry is 1 hour away — well outside the 5-minute refresh window
+    hub.attach_standalone_oauth(
+        oauth,
+        expires_at=time.time() + 3600,
+        refresh_token=creds["refresh_token"],
+    )
+
+    await hub.async_ensure_fresh_token()
+
+    # Token must be unchanged — no network call was made
+    assert hub.token == "sentinel-token"

--- a/tests/test_standalone_oauth_runtime.py
+++ b/tests/test_standalone_oauth_runtime.py
@@ -1,0 +1,216 @@
+"""Unit tests for standalone SmartThings OAuth runtime: token refresh & reauth.
+
+Covers:
+  1. FamilyHub initial state for standalone OAuth attributes
+  2. attach_standalone_oauth populates all attributes
+  3. async_ensure_fresh_token is no-op when no standalone oauth attached
+  4. async_ensure_fresh_token skips refresh when token is not near expiry
+  5. async_ensure_fresh_token refreshes when within 5-minute window
+  6. After refresh, new refresh token is persisted to config entry
+  7. async_ensure_fresh_token raises ConfigEntryAuthFailed on HTTP 401
+
+[Ecthelion Gate-Prover]
+"""
+from __future__ import annotations
+
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+# conftest installs HA stubs before any component imports
+from tests.conftest import _HomeAssistant, _ConfigEntry, _ConfigEntryAuthFailed
+
+from custom_components.samsung_familyhub_fridge.api import FamilyHub
+from custom_components.samsung_familyhub_fridge.const import (
+    CONF_OAUTH_REFRESH_TOKEN,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_hass():
+    hass = _HomeAssistant()
+    return hass
+
+
+def _make_hub(hass=None, token="test-access-token", device_id="device-123"):
+    if hass is None:
+        hass = _make_hass()
+    return FamilyHub(hass, token=token, device_id=device_id)
+
+
+def _make_oauth_creds(access="new-access-token", refresh="new-refresh-token", expires_in=86400):
+    creds = MagicMock()
+    creds.access_token = access
+    creds.refresh_token = refresh
+    creds.expires_in = expires_in
+    return creds
+
+
+def _make_http_error(status_code: int):
+    """Create a requests.HTTPError with the given status code."""
+    resp = requests.models.Response()
+    resp.status_code = status_code
+    err = requests.exceptions.HTTPError(response=resp)
+    return err
+
+
+# ---------------------------------------------------------------------------
+# Test 1: Initial state
+# ---------------------------------------------------------------------------
+
+def test_initial_standalone_oauth_attributes():
+    """FamilyHub starts with standalone OAuth disabled."""
+    hub = _make_hub()
+    assert hub._standalone_oauth is None
+    assert hub._token_expires_at == 0.0
+    assert hub._stored_refresh_token == ""
+    assert hub._config_entry is None
+
+
+# ---------------------------------------------------------------------------
+# Test 2: attach_standalone_oauth populates attributes
+# ---------------------------------------------------------------------------
+
+def test_attach_standalone_oauth_sets_attributes():
+    """attach_standalone_oauth stores oauth instance, expiry, refresh token, entry."""
+    hub = _make_hub()
+    oauth_mock = MagicMock()
+    entry = _ConfigEntry(data={CONF_OAUTH_REFRESH_TOKEN: "old-refresh"})
+    expires_at = time.time() + 3600
+
+    hub.attach_standalone_oauth(
+        oauth_mock,
+        expires_at,
+        refresh_token="stored-refresh",
+        config_entry=entry,
+    )
+
+    assert hub._standalone_oauth is oauth_mock
+    assert hub._token_expires_at == expires_at
+    assert hub._stored_refresh_token == "stored-refresh"
+    assert hub._config_entry is entry
+
+
+# ---------------------------------------------------------------------------
+# Test 3: No-op when standalone oauth not attached
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_ensure_fresh_token_noop_without_standalone_oauth():
+    """async_ensure_fresh_token is a no-op when no standalone oauth is set."""
+    hub = _make_hub()
+    # Should not raise or modify token
+    await hub.async_ensure_fresh_token()
+    assert hub.token == "test-access-token"
+
+
+# ---------------------------------------------------------------------------
+# Test 4: Skips refresh when token is not near expiry
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_ensure_fresh_token_skips_when_not_near_expiry():
+    """Token is not refreshed when more than 5 minutes remain."""
+    hub = _make_hub()
+    oauth_mock = MagicMock()
+    # Expiry is 10 minutes in the future — beyond the 5-minute refresh window
+    hub.attach_standalone_oauth(
+        oauth_mock,
+        expires_at=time.time() + 600,
+        refresh_token="current-refresh",
+    )
+
+    await hub.async_ensure_fresh_token()
+
+    oauth_mock.refresh.assert_not_called()
+    assert hub.token == "test-access-token"
+
+
+# ---------------------------------------------------------------------------
+# Test 5: Refreshes when within 5-minute window
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_ensure_fresh_token_refreshes_when_near_expiry():
+    """Token IS refreshed when within 5 minutes of expiry."""
+    hub = _make_hub()
+    oauth_mock = MagicMock()
+    oauth_mock.refresh.return_value = _make_oauth_creds(
+        access="refreshed-token", refresh="new-refresh", expires_in=86400
+    )
+    # Expiry is only 2 minutes away — inside the 5-minute window
+    hub.attach_standalone_oauth(
+        oauth_mock,
+        expires_at=time.time() + 120,
+        refresh_token="current-refresh",
+    )
+
+    await hub.async_ensure_fresh_token()
+
+    oauth_mock.refresh.assert_called_once_with("current-refresh")
+    assert hub.token == "refreshed-token"
+    assert hub._stored_refresh_token == "new-refresh"
+
+
+# ---------------------------------------------------------------------------
+# Test 6: New refresh token persisted to config entry
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_ensure_fresh_token_persists_new_refresh_token():
+    """After refresh, the new refresh token is written to the config entry."""
+    hass = _make_hass()
+    hub = _make_hub(hass=hass)
+
+    entry = _ConfigEntry(
+        entry_id="entry-1",
+        data={
+            CONF_OAUTH_REFRESH_TOKEN: "old-refresh",
+            "auth_mode": "standalone_oauth",
+        },
+    )
+    oauth_mock = MagicMock()
+    oauth_mock.refresh.return_value = _make_oauth_creds(
+        access="new-access", refresh="rotated-refresh", expires_in=86400
+    )
+    hub.attach_standalone_oauth(
+        oauth_mock,
+        expires_at=time.time() + 60,  # expires in 1 minute — inside window
+        refresh_token="old-refresh",
+        config_entry=entry,
+    )
+
+    await hub.async_ensure_fresh_token()
+
+    # Config entry data should be updated with the new refresh token
+    assert entry.data[CONF_OAUTH_REFRESH_TOKEN] == "rotated-refresh"
+    # Other keys preserved
+    assert entry.data["auth_mode"] == "standalone_oauth"
+    # Hub token updated
+    assert hub.token == "new-access"
+
+
+# ---------------------------------------------------------------------------
+# Test 7: HTTP 401 raises ConfigEntryAuthFailed
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_ensure_fresh_token_raises_config_entry_auth_failed_on_401():
+    """A 401 from the refresh endpoint raises ConfigEntryAuthFailed."""
+    hub = _make_hub()
+    oauth_mock = MagicMock()
+    oauth_mock.refresh.side_effect = _make_http_error(401)
+
+    hub.attach_standalone_oauth(
+        oauth_mock,
+        expires_at=time.time() + 60,  # within window
+        refresh_token="expired-refresh",
+    )
+
+    with pytest.raises(_ConfigEntryAuthFailed):
+        await hub.async_ensure_fresh_token()


### PR DESCRIPTION
[Ecthelion Gate-Prover] — sme-scrum-9

## Task
SCRUM-9 — Standalone SmartThings OAuth: runtime token refresh & setup

## Summary
Wires `auth_mode='standalone_oauth'` into the integration runtime. At startup a
stored refresh token is exchanged for a fresh access token; at each coordinator
poll the token is proactively refreshed when within 5 minutes of expiry. A HTTP
401 from the refresh endpoint raises `ConfigEntryAuthFailed` to trigger HA's
reauth flow. Samsung IoT token is also refreshed at startup when present.

## What changed
- **`api.py`**: `FamilyHub` gains `_standalone_oauth`, `_token_expires_at`,
  `_stored_refresh_token`, `_config_entry` attributes and a new
  `attach_standalone_oauth()` method. `async_ensure_fresh_token()` now has a
  standalone OAuth branch: calls `SmartThingsOAuth.refresh()` when within
  300s of expiry, updates the bearer token, rotates `_stored_refresh_token`,
  persists the new refresh token to the config entry via
  `hass.config_entries.async_update_entry`, and converts HTTP 401 to
  `ConfigEntryAuthFailed`.
- **`__init__.py`**: `async_setup_entry` routes `standalone_oauth` entries to the
  new `_build_standalone_oauth_hub()` helper, which refreshes the token at
  startup, attaches the oauth instance for per-poll refresh, and optionally
  refreshes the Samsung IoT token. `async_migrate_entry` gets an explicit
  comment that v2 `standalone_oauth` entries need no migration. Module docstring
  updated to describe the new auth mode.
- **`config_flow.py`**: `async_step_reauth` handles `standalone_oauth` entries —
  skips to the link step when client credentials are still present, otherwise
  restarts from the credentials step.
- **`tests/conftest.py`**: `_HomeAssistant` stub gains a `config_entries`
  manager (`async_update_entry`, `async_get_entry`, `async_entries`).
  Three new CLI options and a `standalone_oauth_credentials` fixture added for
  real-API integration tests (auto-skip when absent).

## Unit testing
```
pytest tests/test_standalone_oauth_runtime.py -v
```
```
7 passed in 0.02s
```

All 7 cases:
1. `test_initial_standalone_oauth_attributes` — hub starts with standalone oauth disabled
2. `test_attach_standalone_oauth_sets_attributes` — method stores all attributes
3. `test_ensure_fresh_token_noop_without_standalone_oauth` — no-op in PAT/OAuth mode
4. `test_ensure_fresh_token_skips_when_not_near_expiry` — skips when >5min remain
5. `test_ensure_fresh_token_refreshes_when_near_expiry` — calls refresh within window
6. `test_ensure_fresh_token_persists_new_refresh_token` — writes to config entry
7. `test_ensure_fresh_token_raises_config_entry_auth_failed_on_401` — reauth trigger

Full suite: `83 passed, 19 skipped in 0.55s` (no regressions).

## Integration testing (required)
Three real-API tests in `test_standalone_oauth_integration.py` auto-skip without
credentials (fixture calls `pytest.skip()` when CLI flags absent):
```
tests/test_standalone_oauth_integration.py::test_real_oauth_refresh_returns_tokens SKIPPED
tests/test_standalone_oauth_integration.py::test_real_ensure_fresh_token_refreshes SKIPPED
tests/test_standalone_oauth_integration.py::test_real_ensure_fresh_token_skips_when_not_expiring SKIPPED
```
To run with live credentials:
```
pytest tests/test_standalone_oauth_integration.py \
  --standalone-oauth-client-id CID \
  --standalone-oauth-client-secret SECRET \
  --standalone-oauth-refresh-token REFRESH -v
```
The three tests verify: (1) `SmartThingsOAuth.refresh()` returns valid tokens from
the real endpoint; (2) `attach_standalone_oauth` + `async_ensure_fresh_token`
refreshes an expired token and persists the rotated refresh token; (3) a fresh
token (>5min remaining) is not refreshed unnecessarily.

The mocked config-flow integration tests (3 existing) continue to pass:
```
3 passed, 3 skipped in 0.02s
```

## Risks / follow-ups
- `async_step_reauth` for `standalone_oauth` routes to the link step but
  completion calls `async_create_entry` (which HA de-dupes via unique_id in
  production). Full `async_update_reload_and_abort` wiring is deferred to the
  next reauth-polish task.
- `expires_in` defaults to 86400s when the token endpoint omits it (defensive).