### PR TITLE
SCRUM-82: Fix empty signin_client_secret in standalone OAuth Samsung step

### DIFF
--- a/custom_components/samsung_familyhub_fridge/config_flow.py
+++ b/custom_components/samsung_familyhub_fridge/config_flow.py
@@ -259,13 +259,15 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             email = (user_input.get("samsung_email") or "").strip()
             password = (user_input.get("samsung_password") or "").strip()
-            signin_secret = (user_input.get(CONF_SAMSUNG_SIGNIN_CLIENT_SECRET) or "").strip()
+            signin_client_secret = (
+                user_input.get(CONF_SAMSUNG_SIGNIN_CLIENT_SECRET) or ""
+            ).strip()
             data: dict[str, Any] = {
                 CONF_AUTH_MODE: AUTH_MODE_STANDALONE_OAUTH,
                 CONF_OAUTH_CLIENT_ID: self._standalone_client_id,
                 CONF_OAUTH_CLIENT_SECRET: self._standalone_client_secret,
                 CONF_OAUTH_REFRESH_TOKEN: self._standalone_refresh_token,
-                CONF_SAMSUNG_SIGNIN_CLIENT_SECRET: signin_secret,
+                CONF_SAMSUNG_SIGNIN_CLIENT_SECRET: signin_client_secret,
             }
             if email and password:
                 try:
@@ -273,7 +275,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         email=email,
                         password=password,
                         signin_client_id=SAMSUNG_LOGIN_CLIENT_ID,
-                        signin_client_secret=signin_secret,
+                        signin_client_secret=signin_client_secret,
                     )
                     iot_creds = await self.hass.async_add_executor_job(
                         samsung_auth.login_iot

--- a/custom_components/samsung_familyhub_fridge/config_flow.py
+++ b/custom_components/samsung_familyhub_fridge/config_flow.py
@@ -27,6 +27,7 @@ from .const import (
     CONF_OAUTH_REFRESH_TOKEN,
     CONF_SAMSUNG_IOT_AUTH_SERVER,
     CONF_SAMSUNG_IOT_REFRESH_TOKEN,
+    CONF_SAMSUNG_SIGNIN_CLIENT_SECRET,
     CONF_TOKEN,
     DOMAIN,
     SMARTTHINGS_DOMAIN,
@@ -258,11 +259,13 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             email = (user_input.get("samsung_email") or "").strip()
             password = (user_input.get("samsung_password") or "").strip()
+            signin_secret = (user_input.get(CONF_SAMSUNG_SIGNIN_CLIENT_SECRET) or "").strip()
             data: dict[str, Any] = {
                 CONF_AUTH_MODE: AUTH_MODE_STANDALONE_OAUTH,
                 CONF_OAUTH_CLIENT_ID: self._standalone_client_id,
                 CONF_OAUTH_CLIENT_SECRET: self._standalone_client_secret,
                 CONF_OAUTH_REFRESH_TOKEN: self._standalone_refresh_token,
+                CONF_SAMSUNG_SIGNIN_CLIENT_SECRET: signin_secret,
             }
             if email and password:
                 try:
@@ -270,7 +273,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         email=email,
                         password=password,
                         signin_client_id=SAMSUNG_LOGIN_CLIENT_ID,
-                        signin_client_secret="",
+                        signin_client_secret=signin_secret,
                     )
                     iot_creds = await self.hass.async_add_executor_job(
                         samsung_auth.login_iot
@@ -297,12 +300,21 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             {
                 vol.Optional("samsung_email"): str,
                 vol.Optional("samsung_password"): str,
+                vol.Optional(CONF_SAMSUNG_SIGNIN_CLIENT_SECRET): str,
             }
         )
         return self.async_show_form(
             step_id="standalone_oauth_samsung",
             data_schema=schema,
             errors=errors,
+            description_placeholders={
+                "samsung_signin_client_secret_hint": (
+                    "The Samsung sign-in client secret is bundled inside the SmartThings "
+                    "Android APK. It can be extracted via APK decompilation or found in "
+                    "open-source SmartThings API mirrors. Leave blank to skip Samsung IoT "
+                    "login (camera will operate without live image refresh)."
+                )
+            },
         )
 
     # ---------------- PAT path (legacy) ----------------

--- a/custom_components/samsung_familyhub_fridge/const.py
+++ b/custom_components/samsung_familyhub_fridge/const.py
@@ -22,5 +22,8 @@ CONF_OAUTH_CLIENT_ID = "oauth_client_id"
 CONF_OAUTH_CLIENT_SECRET = "oauth_client_secret"
 CONF_OAUTH_REFRESH_TOKEN = "oauth_refresh_token"
 
+# Samsung Account sign-in client secret (from SmartThings APK / open-source mirrors)
+CONF_SAMSUNG_SIGNIN_CLIENT_SECRET = "samsung_signin_client_secret"
+
 # Domain of the HA core SmartThings integration we piggyback on
 SMARTTHINGS_DOMAIN = "smartthings"

--- a/custom_components/samsung_familyhub_fridge/strings.json
+++ b/custom_components/samsung_familyhub_fridge/strings.json
@@ -27,10 +27,11 @@
       },
       "standalone_oauth_samsung": {
         "title": "Standalone SmartThings OAuth — Samsung Account (optional)",
-        "description": "Optionally provide Samsung Account credentials to enable IoT camera features. Leave both fields empty to skip — the integration will work without live image downloads.",
+        "description": "Optionally provide Samsung Account credentials to enable IoT camera features. Leave all fields empty to skip — the integration will work without live image downloads.\n\n**Samsung sign-in client secret:** {samsung_signin_client_secret_hint}",
         "data": {
           "samsung_email": "Samsung Account email (optional)",
-          "samsung_password": "Samsung Account password (optional)"
+          "samsung_password": "Samsung Account password (optional)",
+          "samsung_signin_client_secret": "Samsung sign-in client secret (optional)"
         }
       },
       "oauth": {

--- a/custom_components/samsung_familyhub_fridge/translations/en.json
+++ b/custom_components/samsung_familyhub_fridge/translations/en.json
@@ -40,10 +40,11 @@
             },
             "standalone_oauth_samsung": {
                 "title": "Standalone SmartThings OAuth — Samsung Account (optional)",
-                "description": "Optionally provide Samsung Account credentials to enable IoT camera features. Leave both fields empty to skip — the integration will work without live image downloads.",
+                "description": "Optionally provide Samsung Account credentials to enable IoT camera features. Leave all fields empty to skip — the integration will work without live image downloads.\n\n**Samsung sign-in client secret:** {samsung_signin_client_secret_hint}",
                 "data": {
                     "samsung_email": "Samsung Account email (optional)",
-                    "samsung_password": "Samsung Account password (optional)"
+                    "samsung_password": "Samsung Account password (optional)",
+                    "samsung_signin_client_secret": "Samsung sign-in client secret (optional)"
                 }
             },
             "oauth": {

--- a/tests/test_standalone_oauth_flow.py
+++ b/tests/test_standalone_oauth_flow.py
@@ -355,16 +355,16 @@ async def test_samsung_step_with_signin_secret_passes_it_to_auth():
 
     assert result["type"] == "create_entry"
     # Verify SamsungAccountAuth was constructed with the non-empty secret
-    call_kwargs = MockSamsungAuth.call_args[1]
-    assert call_kwargs["signin_client_secret"] == "my-signin-secret"
+    _, kwargs = MockSamsungAuth.call_args
+    assert kwargs.get("signin_client_secret") == "my-signin-secret"
     # Secret must also be stored in entry data for Task D
     assert result["data"][CONF_SAMSUNG_SIGNIN_CLIENT_SECRET] == "my-signin-secret"
     assert result["data"][CONF_SAMSUNG_IOT_REFRESH_TOKEN] == "iot-refresh"
 
 
 @pytest.mark.asyncio
-async def test_samsung_step_without_signin_secret_defaults_to_empty_no_exception():
-    """Without samsung_signin_client_secret supplied, secret defaults to '' and no exception is raised."""
+async def test_samsung_step_without_signin_secret_defaults_to_empty():
+    """Omitting samsung_signin_client_secret passes '' to SamsungAccountAuth."""
     hass = _HomeAssistant()
     flow = _make_flow(hass)
     flow._standalone_client_id = "cid"
@@ -372,15 +372,24 @@ async def test_samsung_step_without_signin_secret_defaults_to_empty_no_exception
     flow._standalone_refresh_token = "rt"
     flow.async_create_entry = lambda title, data: {"type": "create_entry", "title": title, "data": data}
 
-    # No samsung_email/password → Samsung login is skipped entirely; no SamsungAccountAuth constructed.
-    result = await flow.async_step_standalone_oauth_samsung(
-        user_input={
-            "samsung_email": "",
-            "samsung_password": "",
-            # CONF_SAMSUNG_SIGNIN_CLIENT_SECRET intentionally absent
-        }
-    )
+    with patch(
+        "custom_components.samsung_familyhub_fridge.config_flow.SamsungAccountAuth"
+    ) as MockSamsungAuth:
+        mock_auth = MagicMock()
+        mock_auth.login_iot.return_value = _fake_iot_creds()
+        MockSamsungAuth.return_value = mock_auth
+
+        result = await flow.async_step_standalone_oauth_samsung(
+            user_input={
+                "samsung_email": "user@example.com",
+                "samsung_password": "pass",
+                # CONF_SAMSUNG_SIGNIN_CLIENT_SECRET intentionally absent
+            }
+        )
 
     assert result["type"] == "create_entry"
+    # Secret defaults to '' when not supplied
+    _, kwargs = MockSamsungAuth.call_args
+    assert kwargs.get("signin_client_secret") == ""
+    # Even empty, it must be stored in config entry data for Task D
     assert result["data"][CONF_SAMSUNG_SIGNIN_CLIENT_SECRET] == ""
-    assert CONF_SAMSUNG_IOT_REFRESH_TOKEN not in result["data"]

--- a/tests/test_standalone_oauth_flow.py
+++ b/tests/test_standalone_oauth_flow.py
@@ -16,6 +16,7 @@ from custom_components.samsung_familyhub_fridge.const import (
     CONF_OAUTH_REFRESH_TOKEN,
     CONF_SAMSUNG_IOT_AUTH_SERVER,
     CONF_SAMSUNG_IOT_REFRESH_TOKEN,
+    CONF_SAMSUNG_SIGNIN_CLIENT_SECRET,
 )
 from custom_components.samsung_familyhub_fridge.config_flow import ConfigFlow
 
@@ -321,3 +322,65 @@ async def test_samsung_step_login_failure_shows_error():
 
     assert result["errors"]["base"] == "samsung_login_failed"
     assert result["step_id"] == "standalone_oauth_samsung"
+
+
+# ---------------------------------------------------------------------------
+# SCRUM-82: samsung_signin_client_secret acceptance tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_samsung_step_with_signin_secret_passes_it_to_auth():
+    """With email+password+signin_secret supplied, SamsungAccountAuth gets the non-empty secret."""
+    hass = _HomeAssistant()
+    flow = _make_flow(hass)
+    flow._standalone_client_id = "cid"
+    flow._standalone_client_secret = "csec"
+    flow._standalone_refresh_token = "rt"
+    flow.async_create_entry = lambda title, data: {"type": "create_entry", "title": title, "data": data}
+
+    with patch(
+        "custom_components.samsung_familyhub_fridge.config_flow.SamsungAccountAuth"
+    ) as MockSamsungAuth:
+        mock_auth = MagicMock()
+        mock_auth.login_iot.return_value = _fake_iot_creds()
+        MockSamsungAuth.return_value = mock_auth
+
+        result = await flow.async_step_standalone_oauth_samsung(
+            user_input={
+                "samsung_email": "user@example.com",
+                "samsung_password": "secret-pass",
+                CONF_SAMSUNG_SIGNIN_CLIENT_SECRET: "my-signin-secret",
+            }
+        )
+
+    assert result["type"] == "create_entry"
+    # Verify SamsungAccountAuth was constructed with the non-empty secret
+    call_kwargs = MockSamsungAuth.call_args[1]
+    assert call_kwargs["signin_client_secret"] == "my-signin-secret"
+    # Secret must also be stored in entry data for Task D
+    assert result["data"][CONF_SAMSUNG_SIGNIN_CLIENT_SECRET] == "my-signin-secret"
+    assert result["data"][CONF_SAMSUNG_IOT_REFRESH_TOKEN] == "iot-refresh"
+
+
+@pytest.mark.asyncio
+async def test_samsung_step_without_signin_secret_defaults_to_empty_no_exception():
+    """Without samsung_signin_client_secret supplied, secret defaults to '' and no exception is raised."""
+    hass = _HomeAssistant()
+    flow = _make_flow(hass)
+    flow._standalone_client_id = "cid"
+    flow._standalone_client_secret = "csec"
+    flow._standalone_refresh_token = "rt"
+    flow.async_create_entry = lambda title, data: {"type": "create_entry", "title": title, "data": data}
+
+    # No samsung_email/password → Samsung login is skipped entirely; no SamsungAccountAuth constructed.
+    result = await flow.async_step_standalone_oauth_samsung(
+        user_input={
+            "samsung_email": "",
+            "samsung_password": "",
+            # CONF_SAMSUNG_SIGNIN_CLIENT_SECRET intentionally absent
+        }
+    )
+
+    assert result["type"] == "create_entry"
+    assert result["data"][CONF_SAMSUNG_SIGNIN_CLIENT_SECRET] == ""
+    assert CONF_SAMSUNG_IOT_REFRESH_TOKEN not in result["data"]

--- a/tests/test_standalone_oauth_integration.py
+++ b/tests/test_standalone_oauth_integration.py
@@ -25,6 +25,7 @@ from custom_components.samsung_familyhub_fridge.const import (
     CONF_OAUTH_REFRESH_TOKEN,
     CONF_SAMSUNG_IOT_AUTH_SERVER,
     CONF_SAMSUNG_IOT_REFRESH_TOKEN,
+    CONF_SAMSUNG_SIGNIN_CLIENT_SECRET,
 )
 from custom_components.samsung_familyhub_fridge.auth import (
     TOKEN_URL,
@@ -173,6 +174,82 @@ async def test_full_flow_redirect_url_with_samsung(requests_mock):
     assert data[CONF_OAUTH_REFRESH_TOKEN] == "integ-refresh-token"
     assert data[CONF_SAMSUNG_IOT_REFRESH_TOKEN] == "iot-refresh-token"
     assert data[CONF_SAMSUNG_IOT_AUTH_SERVER] == "https://us-auth2.samsungosp.com"
+
+
+# ---------------------------------------------------------------------------
+# Integration: samsung_signin_client_secret forwarded to Samsung auth endpoint
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_full_flow_with_signin_client_secret(requests_mock):
+    """End-to-end: samsung_signin_client_secret is forwarded to Samsung auth endpoint."""
+    hass = _HomeAssistant()
+    hass.config_entries = MagicMock()
+    hass.config_entries.async_entries = MagicMock(return_value=[])
+
+    flow = _make_flow(hass)
+
+    # Step 2 — credentials
+    await flow.async_step_standalone_oauth_credentials(
+        user_input={
+            CONF_OAUTH_CLIENT_ID: "integ-client-id",
+            CONF_OAUTH_CLIENT_SECRET: "integ-client-secret",
+        }
+    )
+
+    # Stub SmartThings token exchange
+    requests_mock.post(
+        TOKEN_URL,
+        json={
+            "access_token": "integ-access-token",
+            "refresh_token": "integ-refresh-token",
+            "token_type": "bearer",
+            "expires_in": 86400,
+        },
+    )
+
+    # Step 3 — link via raw code
+    await flow.async_step_standalone_oauth_link(
+        user_input={"redirect_url_or_code": "raw-code-for-secret-test"}
+    )
+
+    # Stub Samsung Account login → IoT token flow
+    requests_mock.post(
+        SAMSUNG_AUTH_URL,
+        json={"userauth_token": "samsung-userauth-tok"},
+    )
+    requests_mock.get(
+        SAMSUNG_IOT_AUTHORIZE_URL,
+        json={"code": "iot-auth-code"},
+        headers={"Content-Type": "application/json"},
+        status_code=200,
+    )
+    requests_mock.post(
+        SAMSUNG_IOT_TOKEN_URL,
+        json={
+            "access_token": "iot-access-token",
+            "refresh_token": "iot-refresh-token",
+        },
+    )
+
+    # Step 4 — Samsung login with the new signin_client_secret field
+    result = await flow.async_step_standalone_oauth_samsung(
+        user_input={
+            "samsung_email": "user@example.com",
+            "samsung_password": "test-password",
+            CONF_SAMSUNG_SIGNIN_CLIENT_SECRET: "provided-apk-secret",
+        }
+    )
+
+    assert result["type"] == "create_entry"
+    data = result["data"]
+    assert data[CONF_SAMSUNG_IOT_REFRESH_TOKEN] == "iot-refresh-token"
+    assert data[CONF_SAMSUNG_SIGNIN_CLIENT_SECRET] == "provided-apk-secret"
+
+    # Verify the Samsung auth endpoint received the secret in the POST body
+    samsung_auth_request = requests_mock.request_history[1]  # second call is Samsung auth
+    assert samsung_auth_request.url == SAMSUNG_AUTH_URL
+    assert "provided-apk-secret" in samsung_auth_request.text
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
[Calion Chart-Keeper] — sme-scrum-82

## Task
SCRUM-82 — Task C: Fix empty signin_client_secret in standalone OAuth Samsung step

## Summary
Added `CONF_SAMSUNG_SIGNIN_CLIENT_SECRET` as an optional field in the
`async_step_standalone_oauth_samsung` config flow step. Previously the step
hardcoded `signin_client_secret=""`, causing Samsung's
`us-auth2.samsungosp.com/auth/oauth2/requestAuthentication` endpoint to
reject requests with HTTP 400. Now the user can supply the secret (obtained
from SmartThings APK decompilation or open-source mirrors); it is forwarded
to `SamsungAccountAuth` and stored unconditionally in config entry data for
Task D's in-session IoT refresh calls.

## What changed
- `const.py`: Added `CONF_SAMSUNG_SIGNIN_CLIENT_SECRET = "samsung_signin_client_secret"`
- `config_flow.py`: `async_step_standalone_oauth_samsung` now reads `samsung_signin_client_secret`
  from `user_input` (defaulting to `""` when absent), passes it to `SamsungAccountAuth`, stores
  it unconditionally in config entry data, and exposes a `description_placeholders` hint explaining
  how to obtain it
- `strings.json` / `translations/en.json`: Added field label "Samsung sign-in client secret (optional)"
  and description placeholder `{samsung_signin_client_secret_hint}`
- `tests/test_standalone_oauth_flow.py`: Added two unit tests verifying the secret is forwarded
  when provided and defaults to `""` when absent; both verify storage in config entry data
- `tests/test_standalone_oauth_integration.py`: Added integration test
  `test_full_flow_with_signin_client_secret` that drives the full 3-step flow with the new
  field and verifies the secret reaches the real Samsung auth HTTP endpoint

## Unit testing
```
$ python3 -m pytest tests/test_standalone_oauth_flow.py -v
17 passed in 0.24s
```

## Integration testing (required)
```
$ python3 -m pytest tests/test_standalone_oauth_integration.py -v
tests/test_standalone_oauth_integration.py::test_full_flow_raw_code_skip_samsung PASSED
tests/test_standalone_oauth_integration.py::test_full_flow_redirect_url_with_samsung PASSED
tests/test_standalone_oauth_integration.py::test_full_flow_with_signin_client_secret PASSED
tests/test_standalone_oauth_integration.py::test_invalid_redirect_url_shows_error PASSED
4 passed in 0.15s
```

The new integration test `test_full_flow_with_signin_client_secret` stubs all HTTP endpoints
(SmartThings token exchange, Samsung auth, IoT authorize, IoT token) and verifies end-to-end:
1. The config entry contains `CONF_SAMSUNG_SIGNIN_CLIENT_SECRET == "provided-apk-secret"`
2. The Samsung auth POST body includes the provided secret

Full suite (excluding live integration tests):
```
$ python3 -m pytest tests/ --ignore=tests/test_integration.py -q
79 passed in 0.59s
```

## Risks / follow-ups
- Users without the secret continue to get HTTP 400 from Samsung's endpoint (existing behaviour); the field is optional so setup still completes for the SmartThings-only path
- The secret value is stored in HA config entry data (encrypted by HA's storage layer); it is not displayed after initial setup