### PR TITLE
SCRUM-80: Wire AUTH_MODE_STANDALONE_OAUTH into async_setup_entry

### DIFF
--- a/custom_components/samsung_familyhub_fridge/__init__.py
+++ b/custom_components/samsung_familyhub_fridge/__init__.py
@@ -11,6 +11,10 @@ Auth modes (data["auth_mode"]):
              deprecated indefinite PATs on 2024-12-30 — new PATs expire after
              24 hours. Retained for backwards compatibility only.
 
+- "standalone_oauth" : Custom SmartThings app OAuth2 credentials managed by
+                       this integration directly. Refresh token stored in the
+                       config entry and rotated on each setup/update.
+
 Config entries created before this integration version stored `{token, device_id}`
 without an `auth_mode` key; they are migrated to `auth_mode: "pat"` on first
 load via `async_migrate_entry`.
@@ -30,9 +34,13 @@ from .api import FamilyHub
 from .const import (
     AUTH_MODE_OAUTH,
     AUTH_MODE_PAT,
+    AUTH_MODE_STANDALONE_OAUTH,
     CONF_AUTH_MODE,
     CONF_DEVICE_ID,
     CONF_LINKED_SMARTTHINGS_ENTRY_ID,
+    CONF_OAUTH_CLIENT_ID,
+    CONF_OAUTH_CLIENT_SECRET,
+    CONF_OAUTH_REFRESH_TOKEN,
     CONF_SAMSUNG_IOT_AUTH_SERVER,
     CONF_SAMSUNG_IOT_REFRESH_TOKEN,
     CONF_TOKEN,
@@ -54,6 +62,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     if auth_mode == AUTH_MODE_OAUTH:
         hub = await _build_oauth_hub(hass, entry, device_id)
+    elif auth_mode == AUTH_MODE_STANDALONE_OAUTH:
+        hub = await _build_standalone_oauth_hub(hass, entry, device_id)
     else:
         # Legacy PAT path — unchanged from v0.0.x.
         token = entry.data.get(CONF_TOKEN)
@@ -157,6 +167,80 @@ async def _build_oauth_hub(
     return hub
 
 
+async def _build_standalone_oauth_hub(
+    hass: HomeAssistant, entry: ConfigEntry, device_id: str | None
+) -> FamilyHub:
+    """Construct a FamilyHub using this integration's own OAuth app credentials.
+
+    Refreshes the stored refresh token, persists the rotated token back to the
+    config entry, then optionally attaches a Samsung IoT token for image downloads.
+
+    Raises ConfigEntryNotReady if required credentials are missing or the
+    refresh call fails — HA will retry setup automatically.
+    """
+    client_id = entry.data.get(CONF_OAUTH_CLIENT_ID)
+    client_secret = entry.data.get(CONF_OAUTH_CLIENT_SECRET)
+    refresh_token = entry.data.get(CONF_OAUTH_REFRESH_TOKEN)
+
+    if not client_id or not client_secret or not refresh_token:
+        raise ConfigEntryNotReady(
+            "Standalone OAuth config entry is missing client_id, client_secret, "
+            "or refresh_token. Reconfigure the integration."
+        )
+
+    from .auth import SmartThingsOAuth
+
+    oauth = SmartThingsOAuth(client_id=client_id, client_secret=client_secret)
+    try:
+        creds = await hass.async_add_executor_job(oauth.refresh, refresh_token)
+    except Exception as err:  # pylint: disable=broad-except
+        raise ConfigEntryNotReady(
+            f"Failed to refresh standalone OAuth token: {err}"
+        ) from err
+
+    access_token = creds.access_token
+
+    # Persist rotated refresh token so the next startup uses the latest one.
+    if creds.refresh_token != refresh_token:
+        hass.config_entries.async_update_entry(
+            entry,
+            data={**entry.data, CONF_OAUTH_REFRESH_TOKEN: creds.refresh_token},
+        )
+
+    hub = FamilyHub(hass, token=access_token, device_id=device_id)
+
+    # Attach Samsung IoT token for client.smartthings.com image downloads.
+    iot_refresh = entry.data.get(CONF_SAMSUNG_IOT_REFRESH_TOKEN)
+    iot_server = entry.data.get(
+        CONF_SAMSUNG_IOT_AUTH_SERVER, "https://us-auth2.samsungosp.com"
+    )
+    if iot_refresh:
+        try:
+            from .auth import refresh_samsung_iot_token
+
+            iot_creds = await hass.async_add_executor_job(
+                refresh_samsung_iot_token, iot_refresh, iot_server
+            )
+            hub.set_samsung_iot_token(iot_creds.access_token)
+            if iot_creds.refresh_token != iot_refresh:
+                hass.config_entries.async_update_entry(
+                    entry,
+                    data={
+                        **entry.data,
+                        CONF_SAMSUNG_IOT_REFRESH_TOKEN: iot_creds.refresh_token,
+                    },
+                )
+            _LOGGER.info("Samsung IoT token refreshed for standalone OAuth image downloads")
+        except Exception as err:  # pylint: disable=broad-except
+            _LOGGER.warning(
+                "Could not refresh Samsung IoT token — image downloads "
+                "will fail until resolved: %s",
+                err,
+            )
+
+    return hub
+
+
 async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """Handle config entry updates (e.g. after re-authentication)."""
     hub: FamilyHub = hass.data[DOMAIN]["hub"]
@@ -165,6 +249,11 @@ async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> Non
         new_token = entry.data.get(CONF_TOKEN)
         if new_token:
             hub.update_token(new_token)
+    elif auth_mode == AUTH_MODE_STANDALONE_OAUTH:
+        # Token rotation is handled at setup time via _build_standalone_oauth_hub.
+        # If the entry is updated (e.g. after reauth), re-run setup to pick up
+        # new credentials by triggering a full reload.
+        await hass.config_entries.async_reload(entry.entry_id)
     # OAuth mode refreshes its token automatically — nothing to do here.
 
 

--- a/custom_components/samsung_familyhub_fridge/config_flow.py
+++ b/custom_components/samsung_familyhub_fridge/config_flow.py
@@ -338,12 +338,13 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self, entry_data: dict[str, Any]
     ) -> FlowResult:
         """Handle re-authentication when the token has expired."""
-        # OAuth-mode entries should never reach reauth: HA's OAuth2Session
-        # refreshes transparently and any hard failure is surfaced on the
-        # linked smartthings entry itself. If we do land here, offer both
-        # paths again so the user can re-link.
-        if entry_data.get(CONF_AUTH_MODE) == AUTH_MODE_OAUTH:
+        auth_mode = entry_data.get(CONF_AUTH_MODE)
+        if auth_mode == AUTH_MODE_OAUTH:
+            # OAuth-mode entries should never reach reauth: HA's OAuth2Session
+            # refreshes transparently. If we land here anyway, offer full re-setup.
             return await self.async_step_user()
+        if auth_mode == AUTH_MODE_STANDALONE_OAUTH:
+            return await self.async_step_reauth_standalone_oauth()
         return await self.async_step_reauth_confirm()
 
     async def async_step_reauth_confirm(
@@ -374,6 +375,95 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             step_id="reauth_confirm",
             data_schema=vol.Schema({vol.Required(CONF_TOKEN): str}),
             errors=errors,
+        )
+
+    async def async_step_reauth_standalone_oauth(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Re-enter standalone OAuth client credentials and repeat the auth flow."""
+        reauth_entry = self._get_reauth_entry()
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            client_id = user_input.get(CONF_OAUTH_CLIENT_ID, "").strip()
+            client_secret = user_input.get(CONF_OAUTH_CLIENT_SECRET, "").strip()
+            if not client_id:
+                errors[CONF_OAUTH_CLIENT_ID] = "required"
+            elif not client_secret:
+                errors[CONF_OAUTH_CLIENT_SECRET] = "required"
+            else:
+                oauth = SmartThingsOAuth(
+                    client_id=client_id,
+                    client_secret=client_secret,
+                )
+                self._standalone_oauth = oauth
+                self._standalone_client_id = client_id
+                self._standalone_client_secret = client_secret
+                self._standalone_auth_url = oauth.get_authorization_url()
+                self._reauth_entry = reauth_entry
+                return await self.async_step_reauth_standalone_oauth_link()
+
+        # Pre-fill client_id from existing entry so the user only needs to
+        # re-enter the secret (or replace both if they created a new app).
+        existing_client_id = reauth_entry.data.get(CONF_OAUTH_CLIENT_ID, "")
+        schema = vol.Schema(
+            {
+                vol.Required(CONF_OAUTH_CLIENT_ID, default=existing_client_id): str,
+                vol.Required(CONF_OAUTH_CLIENT_SECRET): str,
+            }
+        )
+        return self.async_show_form(
+            step_id="reauth_standalone_oauth",
+            data_schema=schema,
+            errors=errors,
+        )
+
+    async def async_step_reauth_standalone_oauth_link(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Collect redirect URL or raw auth code during standalone OAuth reauth."""
+        errors: dict[str, str] = {}
+        oauth: SmartThingsOAuth | None = getattr(self, "_standalone_oauth", None)
+        if oauth is None:
+            return await self.async_step_reauth_standalone_oauth()
+
+        auth_url: str = getattr(self, "_standalone_auth_url", "") or oauth.get_authorization_url()
+        reauth_entry = getattr(self, "_reauth_entry", None) or self._get_reauth_entry()
+
+        if user_input is not None:
+            raw = user_input.get("redirect_url_or_code", "").strip()
+            if not raw:
+                errors["redirect_url_or_code"] = "required"
+            else:
+                try:
+                    if raw.startswith("http"):
+                        code = SmartThingsOAuth.extract_code_from_redirect(raw)
+                    else:
+                        code = raw
+                    creds = await self.hass.async_add_executor_job(oauth.exchange_code, code)
+                except ValueError:
+                    errors["redirect_url_or_code"] = "invalid_redirect_url"
+                except Exception:  # pylint: disable=broad-except
+                    _LOGGER.exception("Code exchange failed during reauth")
+                    errors["redirect_url_or_code"] = "code_exchange_failed"
+                else:
+                    new_data = {
+                        **reauth_entry.data,
+                        CONF_OAUTH_CLIENT_ID: self._standalone_client_id,
+                        CONF_OAUTH_CLIENT_SECRET: self._standalone_client_secret,
+                        CONF_OAUTH_REFRESH_TOKEN: creds.refresh_token,
+                        CONF_AUTH_MODE: AUTH_MODE_STANDALONE_OAUTH,
+                    }
+                    return self.async_update_reload_and_abort(
+                        reauth_entry, data=new_data
+                    )
+
+        schema = vol.Schema({"redirect_url_or_code": str})
+        return self.async_show_form(
+            step_id="reauth_standalone_oauth_link",
+            data_schema=schema,
+            errors=errors,
+            description_placeholders={"authorization_url": auth_url},
         )
 
 

--- a/tests/test_standalone_oauth_setup.py
+++ b/tests/test_standalone_oauth_setup.py
@@ -1,0 +1,231 @@
+"""Tests for standalone OAuth auth_mode wiring in async_setup_entry and config_flow.
+
+Acceptance criteria (SCRUM-80):
+- Integration test: config entry with auth_mode=standalone_oauth; mock SmartThings
+  token refresh; assert hub.token is the refreshed access token (not None).
+- Integration test: same + samsung_iot_refresh_token; mock Samsung IoT refresh;
+  assert hub._samsung_iot_headers is set.
+- Unit test: async_step_reauth with standalone OAuth entry routes to
+  async_step_reauth_standalone_oauth, not async_step_reauth_confirm.
+- Run: python3 -m pytest tests/ -k 'standalone_oauth' -v → all pass.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import requests_mock as rm
+
+from tests.conftest import _HomeAssistant, _ConfigEntry
+
+from custom_components.samsung_familyhub_fridge.config_flow import ConfigFlow
+from custom_components.samsung_familyhub_fridge.const import (
+    AUTH_MODE_STANDALONE_OAUTH,
+    CONF_AUTH_MODE,
+    CONF_DEVICE_ID,
+    CONF_OAUTH_CLIENT_ID,
+    CONF_OAUTH_CLIENT_SECRET,
+    CONF_OAUTH_REFRESH_TOKEN,
+    CONF_SAMSUNG_IOT_AUTH_SERVER,
+    CONF_SAMSUNG_IOT_REFRESH_TOKEN,
+    DOMAIN,
+)
+from custom_components.samsung_familyhub_fridge.auth import TOKEN_URL, SAMSUNG_IOT_TOKEN_URL
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_standalone_entry(extra_data=None):
+    data = {
+        CONF_AUTH_MODE: AUTH_MODE_STANDALONE_OAUTH,
+        CONF_OAUTH_CLIENT_ID: "test-client-id",
+        CONF_OAUTH_CLIENT_SECRET: "test-client-secret",
+        CONF_OAUTH_REFRESH_TOKEN: "old-refresh-token",
+        CONF_DEVICE_ID: "fridge-device-id",
+    }
+    if extra_data:
+        data.update(extra_data)
+    return _ConfigEntry(entry_id="test-entry", data=data)
+
+
+def _make_hass(entry):
+    hass = _HomeAssistant()
+    hass.data = {}
+    hass.config_entries = MagicMock()
+    hass.config_entries.async_get_entry = MagicMock(return_value=None)
+    hass.config_entries.async_update_entry = MagicMock()
+    hass.config_entries.async_forward_entry_setups = AsyncMock(return_value=True)
+    hass.config_entries.async_reload = AsyncMock()
+    hass.services = MagicMock()
+    hass.services.async_register = MagicMock()
+    return hass
+
+
+# ---------------------------------------------------------------------------
+# Integration test 1: hub.token is the refreshed access token (not None)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_setup_entry_standalone_oauth_sets_hub_token(requests_mock):
+    """async_setup_entry with standalone_oauth calls SmartThings token refresh and
+    sets hub.token to the new access token."""
+    # Stub SmartThings token refresh endpoint
+    requests_mock.post(
+        TOKEN_URL,
+        json={
+            "access_token": "fresh-access-token",
+            "refresh_token": "new-refresh-token",
+            "token_type": "bearer",
+            "expires_in": 86400,
+        },
+    )
+
+    entry = _make_standalone_entry()
+    hass = _make_hass(entry)
+
+    from custom_components.samsung_familyhub_fridge import async_setup_entry
+
+    result = await async_setup_entry(hass, entry)
+
+    assert result is True
+    hub = hass.data[DOMAIN]["hub"]
+    assert hub.token == "fresh-access-token", (
+        f"Expected hub.token='fresh-access-token', got {hub.token!r}"
+    )
+    assert hub.token is not None
+
+
+# ---------------------------------------------------------------------------
+# Integration test 2: Samsung IoT token is attached when refresh token present
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_setup_entry_standalone_oauth_attaches_samsung_iot_token(requests_mock):
+    """async_setup_entry with standalone_oauth and samsung_iot_refresh_token
+    calls the Samsung IoT refresh endpoint and sets hub._samsung_iot_headers."""
+    # Stub SmartThings token refresh
+    requests_mock.post(
+        TOKEN_URL,
+        json={
+            "access_token": "fresh-access-token",
+            "refresh_token": "new-refresh-token",
+            "token_type": "bearer",
+            "expires_in": 86400,
+        },
+    )
+    # Stub Samsung IoT refresh endpoint
+    requests_mock.post(
+        "https://us-auth2.samsungosp.com/auth/oauth2/token",
+        json={
+            "access_token": "iot-fresh-access-token",
+            "refresh_token": "iot-new-refresh-token",
+        },
+    )
+
+    entry = _make_standalone_entry(extra_data={
+        CONF_SAMSUNG_IOT_REFRESH_TOKEN: "iot-old-refresh-token",
+        CONF_SAMSUNG_IOT_AUTH_SERVER: "https://us-auth2.samsungosp.com",
+    })
+    hass = _make_hass(entry)
+
+    from custom_components.samsung_familyhub_fridge import async_setup_entry
+
+    result = await async_setup_entry(hass, entry)
+
+    assert result is True
+    hub = hass.data[DOMAIN]["hub"]
+    assert hub.token == "fresh-access-token"
+    # Samsung IoT headers should be present and contain the fresh token
+    assert hub._samsung_iot_headers is not None, (
+        "hub._samsung_iot_headers should be set after Samsung IoT token refresh"
+    )
+    assert "iot-fresh-access-token" in hub._samsung_iot_headers.get("Authorization", ""), (
+        f"Expected 'iot-fresh-access-token' in Authorization header, "
+        f"got: {hub._samsung_iot_headers}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Unit test: reauth routing
+# ---------------------------------------------------------------------------
+
+def _make_flow_for_reauth(entry):
+    """Build a ConfigFlow with reauth entry wired up."""
+    flow = ConfigFlow()
+    flow.hass = _HomeAssistant()
+    flow.hass.config_entries = MagicMock()
+    flow.hass.config_entries.async_entries = MagicMock(return_value=[])
+    # Wire _get_reauth_entry to return our entry
+    flow._get_reauth_entry = MagicMock(return_value=entry)
+    return flow
+
+
+@pytest.mark.asyncio
+async def test_reauth_standalone_oauth_routes_to_standalone_step():
+    """async_step_reauth with standalone_oauth entry must route to
+    async_step_reauth_standalone_oauth, NOT async_step_reauth_confirm."""
+    entry = _make_standalone_entry()
+    flow = _make_flow_for_reauth(entry)
+
+    result = await flow.async_step_reauth(entry.data)
+
+    assert result["step_id"] == "reauth_standalone_oauth", (
+        f"Expected step_id='reauth_standalone_oauth', got {result['step_id']!r}. "
+        "Standalone OAuth reauth must NOT route to reauth_confirm (the PAT step)."
+    )
+
+
+@pytest.mark.asyncio
+async def test_reauth_pat_entry_routes_to_confirm_step():
+    """async_step_reauth with PAT entry still routes to async_step_reauth_confirm."""
+    from custom_components.samsung_familyhub_fridge.const import AUTH_MODE_PAT, CONF_TOKEN
+    entry = _ConfigEntry(entry_id="pat-entry", data={
+        CONF_AUTH_MODE: AUTH_MODE_PAT,
+        CONF_TOKEN: "old-pat",
+    })
+    flow = _make_flow_for_reauth(entry)
+
+    result = await flow.async_step_reauth(entry.data)
+
+    assert result["step_id"] == "reauth_confirm", (
+        f"PAT entries should still route to reauth_confirm, got {result['step_id']!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_reauth_standalone_oauth_full_flow(requests_mock):
+    """Full reauth flow: credentials → link (raw code) → new refresh token saved."""
+    entry = _make_standalone_entry()
+    flow = _make_flow_for_reauth(entry)
+
+    # Step 1: enter credentials
+    result = await flow.async_step_reauth_standalone_oauth(
+        user_input={
+            CONF_OAUTH_CLIENT_ID: "new-client-id",
+            CONF_OAUTH_CLIENT_SECRET: "new-client-secret",
+        }
+    )
+    assert result["step_id"] == "reauth_standalone_oauth_link", (
+        f"Expected link step after credentials, got: {result}"
+    )
+
+    # Stub token exchange
+    requests_mock.post(
+        TOKEN_URL,
+        json={
+            "access_token": "reauth-access-token",
+            "refresh_token": "reauth-refresh-token",
+            "token_type": "bearer",
+            "expires_in": 86400,
+        },
+    )
+
+    # Step 2: provide auth code
+    result = await flow.async_step_reauth_standalone_oauth_link(
+        user_input={"redirect_url_or_code": "reauth-code-xyz"}
+    )
+    assert result["type"] == "abort", (
+        f"Expected abort (reauth_successful) after code exchange, got: {result}"
+    )


### PR DESCRIPTION
[Ecthelion Gate-Prover] — sme-scrum-80

## Task
SCRUM-80 — Task B: Wire AUTH_MODE_STANDALONE_OAUTH into async_setup_entry

## Summary
`async_setup_entry` previously only branched on `AUTH_MODE_OAUTH`; standalone OAuth entries fell through to the legacy PAT branch which read `CONF_TOKEN`. Since standalone OAuth entries store their token under `CONF_OAUTH_REFRESH_TOKEN`, `hub.token` was `None` and every API call immediately failed. This PR adds `_build_standalone_oauth_hub()` and wires it into the entry setup, and also fixes the reauth routing so standalone OAuth users are sent to the correct re-authorization flow.

## What changed
- **`__init__.py`**: Added `_build_standalone_oauth_hub()` — reads client_id/secret/refresh_token, calls `SmartThingsOAuth.refresh()` to get a fresh access token, constructs `FamilyHub` with it, persists the rotated refresh token back to the config entry, and attaches Samsung IoT token if present. Added `AUTH_MODE_STANDALONE_OAUTH` branch in `async_setup_entry`. Updated `_async_update_listener` to reload on standalone OAuth credential updates.
- **`config_flow.py`**: Fixed `async_step_reauth` to route `AUTH_MODE_STANDALONE_OAUTH` entries to `async_step_reauth_standalone_oauth` (new step), not `async_step_reauth_confirm` (the PAT flow). Added `async_step_reauth_standalone_oauth` and `async_step_reauth_standalone_oauth_link` steps that re-collect client credentials and perform a fresh code exchange.
- **`tests/test_standalone_oauth_setup.py`**: New integration and unit tests covering all acceptance criteria.

## Unit testing
```
python3 -m pytest tests/ --ignore=tests/test_integration.py -v
# 81 passed in 0.34s
```

## Integration testing (required)
Integration tests drive `async_setup_entry` against a live stub of the SmartThings token endpoint and the Samsung IoT refresh endpoint:

```
python3 -m pytest tests/ -k 'standalone_oauth' -v
```
```
tests/test_standalone_oauth_setup.py::test_setup_entry_standalone_oauth_sets_hub_token PASSED
tests/test_standalone_oauth_setup.py::test_setup_entry_standalone_oauth_attaches_samsung_iot_token PASSED
tests/test_standalone_oauth_setup.py::test_reauth_standalone_oauth_routes_to_standalone_step PASSED
tests/test_standalone_oauth_setup.py::test_reauth_pat_entry_routes_to_confirm_step PASSED
tests/test_standalone_oauth_setup.py::test_reauth_standalone_oauth_full_flow PASSED
... (18 more standalone_oauth tests)
23 passed in 0.15s
```

Key assertions verified end-to-end:
- `hub.token == "fresh-access-token"` (not None) after `async_setup_entry` with `auth_mode=standalone_oauth`
- `hub._samsung_iot_headers` is set and contains the refreshed IoT access token when `samsung_iot_refresh_token` is present
- `async_step_reauth` with `AUTH_MODE_STANDALONE_OAUTH` routes to `step_id=reauth_standalone_oauth`, not `reauth_confirm`

## Risks / follow-ups
- `_async_update_listener` triggers a full `async_reload` for standalone OAuth updates — this causes a brief gap while the entry is reloaded. A lighter-weight approach (just refreshing the token in-place) could be added later if the reload latency is noticeable.
- The reauth flow for standalone OAuth re-enters a full code exchange (browser visit required). A future improvement could add a "just refresh the existing token" fast path that only asks for a new refresh token string.