### PR TITLE
SCRUM-81: Wire AUTH_MODE_STANDALONE_OAUTH into async_setup_entry

### DIFF
--- a/custom_components/samsung_familyhub_fridge/__init__.py
+++ b/custom_components/samsung_familyhub_fridge/__init__.py
@@ -2,14 +2,22 @@
 
 Auth modes (data["auth_mode"]):
 
-- "oauth"  : Reuse the HA core `smartthings` integration's OAuth2 credentials.
-             Tokens refresh automatically via HA's OAuth2Session — no manual
-             PAT rotation. Requires a working `smartthings` config entry
-             referenced by `data["linked_smartthings_entry_id"]`.
+- "oauth"            : Reuse the HA core `smartthings` integration's OAuth2
+                       credentials. Tokens refresh automatically via HA's
+                       OAuth2Session — no manual PAT rotation. Requires a
+                       working `smartthings` config entry referenced by
+                       `data["linked_smartthings_entry_id"]`.
 
-- "pat"    : Legacy SmartThings Personal Access Token (raw string). Samsung
-             deprecated indefinite PATs on 2024-12-30 — new PATs expire after
-             24 hours. Retained for backwards compatibility only.
+- "standalone_oauth" : Custom SmartThings app credentials (client_id +
+                       client_secret + refresh_token). Tokens are refreshed
+                       from `data["oauth_refresh_token"]` on every setup.
+                       The rotated refresh token is persisted back to the
+                       config entry automatically.
+
+- "pat"              : Legacy SmartThings Personal Access Token (raw string).
+                       Samsung deprecated indefinite PATs on 2024-12-30 — new
+                       PATs expire after 24 hours. Retained for backwards
+                       compatibility only.
 
 Config entries created before this integration version stored `{token, device_id}`
 without an `auth_mode` key; they are migrated to `auth_mode: "pat"` on first
@@ -30,9 +38,13 @@ from .api import FamilyHub
 from .const import (
     AUTH_MODE_OAUTH,
     AUTH_MODE_PAT,
+    AUTH_MODE_STANDALONE_OAUTH,
     CONF_AUTH_MODE,
     CONF_DEVICE_ID,
     CONF_LINKED_SMARTTHINGS_ENTRY_ID,
+    CONF_OAUTH_CLIENT_ID,
+    CONF_OAUTH_CLIENT_SECRET,
+    CONF_OAUTH_REFRESH_TOKEN,
     CONF_SAMSUNG_IOT_AUTH_SERVER,
     CONF_SAMSUNG_IOT_REFRESH_TOKEN,
     CONF_TOKEN,
@@ -54,6 +66,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     if auth_mode == AUTH_MODE_OAUTH:
         hub = await _build_oauth_hub(hass, entry, device_id)
+    elif auth_mode == AUTH_MODE_STANDALONE_OAUTH:
+        hub = await _build_standalone_oauth_hub(hass, entry, device_id)
     else:
         # Legacy PAT path — unchanged from v0.0.x.
         token = entry.data.get(CONF_TOKEN)
@@ -157,6 +171,69 @@ async def _build_oauth_hub(
     return hub
 
 
+async def _build_standalone_oauth_hub(
+    hass: HomeAssistant, entry: ConfigEntry, device_id: str | None
+) -> FamilyHub:
+    """Construct a FamilyHub using standalone SmartThings OAuth credentials.
+
+    Reads client_id, client_secret, and refresh_token from the config entry,
+    performs a token refresh to obtain a fresh access token, and persists the
+    rotated refresh token back to the entry for next startup.
+    """
+    from .auth import SmartThingsOAuth, refresh_samsung_iot_token
+
+    client_id = entry.data.get(CONF_OAUTH_CLIENT_ID)
+    client_secret = entry.data.get(CONF_OAUTH_CLIENT_SECRET)
+    refresh_token = entry.data.get(CONF_OAUTH_REFRESH_TOKEN)
+
+    if not client_id or not client_secret or not refresh_token:
+        raise ConfigEntryNotReady(
+            "Standalone OAuth entry is missing credentials "
+            "(oauth_client_id / oauth_client_secret / oauth_refresh_token). "
+            "Reconfigure the integration in Settings → Devices & Services."
+        )
+
+    oauth = SmartThingsOAuth(client_id=client_id, client_secret=client_secret)
+    try:
+        creds = await hass.async_add_executor_job(oauth.refresh, refresh_token)
+    except Exception as err:  # pylint: disable=broad-except
+        raise ConfigEntryNotReady(
+            f"Failed to refresh standalone OAuth token: {err}"
+        ) from err
+
+    if creds.refresh_token != refresh_token:
+        new_data = {**entry.data, CONF_OAUTH_REFRESH_TOKEN: creds.refresh_token}
+        hass.config_entries.async_update_entry(entry, data=new_data)
+
+    hub = FamilyHub(hass, token=creds.access_token, device_id=device_id)
+
+    iot_refresh = entry.data.get(CONF_SAMSUNG_IOT_REFRESH_TOKEN)
+    iot_server = entry.data.get(
+        CONF_SAMSUNG_IOT_AUTH_SERVER, "https://us-auth2.samsungosp.com"
+    )
+    if iot_refresh:
+        try:
+            iot_creds = await hass.async_add_executor_job(
+                refresh_samsung_iot_token, iot_refresh, iot_server
+            )
+            hub.set_samsung_iot_token(iot_creds.access_token)
+            if iot_creds.refresh_token != iot_refresh:
+                new_data = {
+                    **entry.data,
+                    CONF_SAMSUNG_IOT_REFRESH_TOKEN: iot_creds.refresh_token,
+                }
+                hass.config_entries.async_update_entry(entry, data=new_data)
+            _LOGGER.info("Samsung IoT token refreshed for standalone OAuth entry")
+        except Exception as err:  # pylint: disable=broad-except
+            _LOGGER.warning(
+                "Could not refresh Samsung IoT token for standalone OAuth entry "
+                "— image downloads will fail until resolved: %s",
+                err,
+            )
+
+    return hub
+
+
 async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """Handle config entry updates (e.g. after re-authentication)."""
     hub: FamilyHub = hass.data[DOMAIN]["hub"]
@@ -165,6 +242,30 @@ async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> Non
         new_token = entry.data.get(CONF_TOKEN)
         if new_token:
             hub.update_token(new_token)
+    elif auth_mode == AUTH_MODE_STANDALONE_OAUTH:
+        from .auth import SmartThingsOAuth
+
+        client_id = entry.data.get(CONF_OAUTH_CLIENT_ID)
+        client_secret = entry.data.get(CONF_OAUTH_CLIENT_SECRET)
+        refresh_token = entry.data.get(CONF_OAUTH_REFRESH_TOKEN)
+        if client_id and client_secret and refresh_token:
+            try:
+                oauth = SmartThingsOAuth(
+                    client_id=client_id, client_secret=client_secret
+                )
+                creds = await hass.async_add_executor_job(oauth.refresh, refresh_token)
+                hub.update_token(creds.access_token)
+                if creds.refresh_token != refresh_token:
+                    new_data = {
+                        **entry.data,
+                        CONF_OAUTH_REFRESH_TOKEN: creds.refresh_token,
+                    }
+                    hass.config_entries.async_update_entry(entry, data=new_data)
+            except Exception as err:  # pylint: disable=broad-except
+                _LOGGER.warning(
+                    "Could not refresh standalone OAuth token on config update: %s",
+                    err,
+                )
     # OAuth mode refreshes its token automatically — nothing to do here.
 
 

--- a/custom_components/samsung_familyhub_fridge/config_flow.py
+++ b/custom_components/samsung_familyhub_fridge/config_flow.py
@@ -344,6 +344,8 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         # paths again so the user can re-link.
         if entry_data.get(CONF_AUTH_MODE) == AUTH_MODE_OAUTH:
             return await self.async_step_user()
+        if entry_data.get(CONF_AUTH_MODE) == AUTH_MODE_STANDALONE_OAUTH:
+            return await self.async_step_reauth_standalone_oauth()
         return await self.async_step_reauth_confirm()
 
     async def async_step_reauth_confirm(
@@ -374,6 +376,95 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             step_id="reauth_confirm",
             data_schema=vol.Schema({vol.Required(CONF_TOKEN): str}),
             errors=errors,
+        )
+
+
+    async def async_step_reauth_standalone_oauth(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Step 1 of standalone OAuth re-auth: collect client credentials."""
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            client_id = user_input.get(CONF_OAUTH_CLIENT_ID, "").strip()
+            client_secret = user_input.get(CONF_OAUTH_CLIENT_SECRET, "").strip()
+            if not client_id:
+                errors[CONF_OAUTH_CLIENT_ID] = "required"
+            elif not client_secret:
+                errors[CONF_OAUTH_CLIENT_SECRET] = "required"
+            else:
+                oauth = SmartThingsOAuth(
+                    client_id=client_id, client_secret=client_secret
+                )
+                self._reauth_standalone_oauth = oauth
+                self._reauth_standalone_client_id = client_id
+                self._reauth_standalone_client_secret = client_secret
+                self._reauth_standalone_auth_url = oauth.get_authorization_url()
+                return await self.async_step_reauth_standalone_oauth_link()
+
+        schema = vol.Schema(
+            {
+                vol.Required(CONF_OAUTH_CLIENT_ID): str,
+                vol.Required(CONF_OAUTH_CLIENT_SECRET): str,
+            }
+        )
+        return self.async_show_form(
+            step_id="reauth_standalone_oauth",
+            data_schema=schema,
+            errors=errors,
+        )
+
+    async def async_step_reauth_standalone_oauth_link(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Step 2 of standalone OAuth re-auth: display auth URL, collect code."""
+        errors: dict[str, str] = {}
+        oauth: SmartThingsOAuth | None = getattr(
+            self, "_reauth_standalone_oauth", None
+        )
+        if oauth is None:
+            return await self.async_step_reauth_standalone_oauth()
+
+        auth_url: str = (
+            getattr(self, "_reauth_standalone_auth_url", "")
+            or oauth.get_authorization_url()
+        )
+
+        if user_input is not None:
+            raw = user_input.get("redirect_url_or_code", "").strip()
+            if not raw:
+                errors["redirect_url_or_code"] = "required"
+            else:
+                try:
+                    if raw.startswith("http"):
+                        code = SmartThingsOAuth.extract_code_from_redirect(raw)
+                    else:
+                        code = raw
+                    creds = await self.hass.async_add_executor_job(
+                        oauth.exchange_code, code
+                    )
+                except ValueError:
+                    errors["redirect_url_or_code"] = "invalid_redirect_url"
+                except Exception:  # pylint: disable=broad-except
+                    _LOGGER.exception("Code exchange failed during reauth")
+                    errors["redirect_url_or_code"] = "code_exchange_failed"
+                else:
+                    reauth_entry = self._get_reauth_entry()
+                    new_data = {
+                        **reauth_entry.data,
+                        CONF_OAUTH_CLIENT_ID: self._reauth_standalone_client_id,
+                        CONF_OAUTH_CLIENT_SECRET: self._reauth_standalone_client_secret,
+                        CONF_OAUTH_REFRESH_TOKEN: creds.refresh_token,
+                    }
+                    return self.async_update_reload_and_abort(
+                        reauth_entry, data=new_data
+                    )
+
+        schema = vol.Schema({"redirect_url_or_code": str})
+        return self.async_show_form(
+            step_id="reauth_standalone_oauth_link",
+            data_schema=schema,
+            errors=errors,
+            description_placeholders={"authorization_url": auth_url},
         )
 
 

--- a/tests/test_standalone_oauth_setup.py
+++ b/tests/test_standalone_oauth_setup.py
@@ -1,0 +1,212 @@
+"""Tests for AUTH_MODE_STANDALONE_OAUTH wired into async_setup_entry and reauth.
+
+Integration tests: construct a config entry with auth_mode=standalone_oauth,
+mock the SmartThings / Samsung IoT refresh endpoints, call async_setup_entry,
+assert the hub has the expected tokens.
+
+Unit test: async_step_reauth routes standalone OAuth entries to
+async_step_reauth_standalone_oauth (not async_step_reauth_confirm).
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from tests.conftest import _ConfigEntry, _HomeAssistant, _ServiceRegistry
+
+from custom_components.samsung_familyhub_fridge.auth import (
+    SAMSUNG_IOT_TOKEN_URL,
+    SAMSUNG_IOT_AUTHORIZE_URL,
+    TOKEN_URL,
+)
+from custom_components.samsung_familyhub_fridge.const import (
+    AUTH_MODE_STANDALONE_OAUTH,
+    CONF_AUTH_MODE,
+    CONF_DEVICE_ID,
+    CONF_OAUTH_CLIENT_ID,
+    CONF_OAUTH_CLIENT_SECRET,
+    CONF_OAUTH_REFRESH_TOKEN,
+    CONF_SAMSUNG_IOT_AUTH_SERVER,
+    CONF_SAMSUNG_IOT_REFRESH_TOKEN,
+    DOMAIN,
+)
+from custom_components.samsung_familyhub_fridge.config_flow import ConfigFlow
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_hass():
+    hass = _HomeAssistant()
+    hass.data = {}
+    hass.services = _ServiceRegistry()
+    hass.config_entries = MagicMock()
+    hass.config_entries.async_forward_entry_setups = AsyncMock(return_value=True)
+    hass.config_entries.async_update_entry = MagicMock()
+    return hass
+
+
+def _make_flow(hass) -> ConfigFlow:
+    flow = ConfigFlow()
+    flow.hass = hass
+    return flow
+
+
+# ---------------------------------------------------------------------------
+# Integration test 1: standalone OAuth setup gets refreshed access token
+# ---------------------------------------------------------------------------
+
+
+async def test_setup_entry_standalone_oauth_refreshes_token(requests_mock):
+    """async_setup_entry with standalone_oauth uses the refreshed access token."""
+    hass = _make_hass()
+    entry = _ConfigEntry(
+        entry_id="se-standalone-1",
+        data={
+            CONF_AUTH_MODE: AUTH_MODE_STANDALONE_OAUTH,
+            CONF_OAUTH_CLIENT_ID: "client-id-1",
+            CONF_OAUTH_CLIENT_SECRET: "client-secret-1",
+            CONF_OAUTH_REFRESH_TOKEN: "old-refresh-token",
+            CONF_DEVICE_ID: "device-abc",
+        },
+    )
+
+    requests_mock.post(
+        TOKEN_URL,
+        json={
+            "access_token": "fresh-access-token",
+            "refresh_token": "old-refresh-token",
+            "token_type": "bearer",
+            "expires_in": 86400,
+        },
+    )
+
+    from custom_components.samsung_familyhub_fridge import async_setup_entry
+
+    result = await async_setup_entry(hass, entry)
+
+    assert result is True
+    hub = hass.data[DOMAIN]["hub"]
+    assert hub.token == "fresh-access-token", (
+        f"Expected hub.token='fresh-access-token', got {hub.token!r}"
+    )
+    assert hub._samsung_iot_headers is None
+
+
+# ---------------------------------------------------------------------------
+# Integration test 2: standalone OAuth setup with Samsung IoT token
+# ---------------------------------------------------------------------------
+
+
+async def test_setup_entry_standalone_oauth_with_samsung_iot(requests_mock):
+    """async_setup_entry with standalone_oauth + IoT token sets samsung_iot_headers."""
+    hass = _make_hass()
+    entry = _ConfigEntry(
+        entry_id="se-standalone-2",
+        data={
+            CONF_AUTH_MODE: AUTH_MODE_STANDALONE_OAUTH,
+            CONF_OAUTH_CLIENT_ID: "client-id-2",
+            CONF_OAUTH_CLIENT_SECRET: "client-secret-2",
+            CONF_OAUTH_REFRESH_TOKEN: "st-refresh-token",
+            CONF_DEVICE_ID: "device-xyz",
+            CONF_SAMSUNG_IOT_REFRESH_TOKEN: "iot-refresh-token",
+            CONF_SAMSUNG_IOT_AUTH_SERVER: "https://us-auth2.samsungosp.com",
+        },
+    )
+
+    # Mock SmartThings token refresh
+    requests_mock.post(
+        TOKEN_URL,
+        json={
+            "access_token": "fresh-st-access-token",
+            "refresh_token": "st-refresh-token",
+            "token_type": "bearer",
+            "expires_in": 86400,
+        },
+    )
+
+    # Mock Samsung IoT token refresh
+    requests_mock.post(
+        "https://us-auth2.samsungosp.com/auth/oauth2/token",
+        json={
+            "access_token": "fresh-iot-access-token",
+            "refresh_token": "iot-refresh-token",
+        },
+    )
+
+    from custom_components.samsung_familyhub_fridge import async_setup_entry
+
+    result = await async_setup_entry(hass, entry)
+
+    assert result is True
+    hub = hass.data[DOMAIN]["hub"]
+    assert hub.token == "fresh-st-access-token"
+    assert hub._samsung_iot_headers is not None, (
+        "Expected hub._samsung_iot_headers to be set after IoT token refresh"
+    )
+    assert hub._samsung_iot_headers["Authorization"] == "Bearer fresh-iot-access-token"
+
+
+# ---------------------------------------------------------------------------
+# Integration test 3: missing credentials → ConfigEntryNotReady
+# ---------------------------------------------------------------------------
+
+
+async def test_setup_entry_standalone_oauth_missing_creds():
+    """async_setup_entry raises ConfigEntryNotReady when credentials are absent."""
+    from homeassistant.exceptions import ConfigEntryNotReady
+
+    hass = _make_hass()
+    entry = _ConfigEntry(
+        entry_id="se-standalone-3",
+        data={
+            CONF_AUTH_MODE: AUTH_MODE_STANDALONE_OAUTH,
+            CONF_DEVICE_ID: "device-123",
+            # oauth credentials deliberately omitted
+        },
+    )
+
+    from custom_components.samsung_familyhub_fridge import async_setup_entry
+
+    with pytest.raises(ConfigEntryNotReady):
+        await async_setup_entry(hass, entry)
+
+
+# ---------------------------------------------------------------------------
+# Unit test: reauth routing
+# ---------------------------------------------------------------------------
+
+
+async def test_reauth_standalone_oauth_routes_to_correct_step():
+    """async_step_reauth for a standalone_oauth entry routes to reauth_standalone_oauth."""
+    hass = _make_hass()
+    hass.config_entries.async_entries = MagicMock(return_value=[])
+    flow = _make_flow(hass)
+
+    result = await flow.async_step_reauth(
+        {
+            CONF_AUTH_MODE: AUTH_MODE_STANDALONE_OAUTH,
+            CONF_OAUTH_CLIENT_ID: "client-id",
+            CONF_OAUTH_CLIENT_SECRET: "client-secret",
+            CONF_OAUTH_REFRESH_TOKEN: "refresh-token",
+        }
+    )
+
+    assert result["type"] == "form", f"Expected form, got: {result}"
+    assert result["step_id"] == "reauth_standalone_oauth", (
+        f"Expected step 'reauth_standalone_oauth', got '{result['step_id']}'"
+    )
+
+
+async def test_reauth_pat_routes_to_reauth_confirm():
+    """async_step_reauth for a PAT entry still routes to reauth_confirm (unchanged)."""
+    hass = _make_hass()
+    hass.config_entries.async_entries = MagicMock(return_value=[])
+    flow = _make_flow(hass)
+
+    result = await flow.async_step_reauth({"auth_mode": "pat", "token": "old-pat"})
+
+    assert result["step_id"] == "reauth_confirm"


### PR DESCRIPTION
[Calion Chart-Keeper] — sme-scrum-81

## Task
SCRUM-81 — Task B: Wire AUTH_MODE_STANDALONE_OAUTH into async_setup_entry

## Summary
Standalone OAuth config entries previously fell through to the PAT branch in
`async_setup_entry`, which read `CONF_TOKEN` (absent in standalone OAuth entries),
leaving `hub.token = None` and causing every API call to immediately fail. This PR
adds the missing `AUTH_MODE_STANDALONE_OAUTH` branch, the `_build_standalone_oauth_hub()`
helper that performs token refresh, and fixes the reauth routing bug in `config_flow.py`.

## What changed
- `__init__.py`: Added `_build_standalone_oauth_hub()` — reads `oauth_client_id`,
  `oauth_client_secret`, `oauth_refresh_token`; calls `SmartThingsOAuth.refresh()` to
  get a fresh access token; creates `FamilyHub(hass, token=access_token, device_id=...)`
  and persists any rotated refresh token back to the config entry; also refreshes the
  Samsung IoT token if `samsung_iot_refresh_token` is present.
- `__init__.py`: Added `elif auth_mode == AUTH_MODE_STANDALONE_OAUTH` branch in
  `async_setup_entry` that calls `_build_standalone_oauth_hub()`.
- `__init__.py`: Updated `_async_update_listener` to handle standalone OAuth token
  rotation — re-derives the access token from the (potentially rotated) refresh token
  when the config entry is updated.
- `config_flow.py`: Fixed `async_step_reauth` to route standalone OAuth entries to new
  `async_step_reauth_standalone_oauth` instead of `async_step_reauth_confirm`.
- `config_flow.py`: Added `async_step_reauth_standalone_oauth` (collect client
  credentials) and `async_step_reauth_standalone_oauth_link` (show auth URL, collect
  code, update entry with new refresh token).
- `tests/test_standalone_oauth_setup.py`: New test file with 5 tests.

## Unit testing
```
python3 -m pytest tests/ --ignore=tests/test_integration.py -q
76 passed → 81 passed (5 new tests added)
```

## Integration testing (required)
Tests drive `async_setup_entry` against a real-module mock (requests_mock intercepts
HTTP, all HA machinery is exercised through the integration's actual code path):

```
python3 -m pytest tests/ -k 'standalone_oauth' -v

tests/test_standalone_oauth_setup.py::test_setup_entry_standalone_oauth_refreshes_token PASSED
tests/test_standalone_oauth_setup.py::test_setup_entry_standalone_oauth_with_samsung_iot PASSED
tests/test_standalone_oauth_setup.py::test_setup_entry_standalone_oauth_missing_creds PASSED
tests/test_standalone_oauth_setup.py::test_reauth_standalone_oauth_routes_to_correct_step PASSED
tests/test_standalone_oauth_setup.py::test_reauth_pat_routes_to_reauth_confirm PASSED
... (18 more pre-existing standalone_oauth tests)
23 passed in 0.22s

python3 -m pytest tests/ --ignore=tests/test_integration.py
81 passed in 0.40s
```

Test 1 (`test_setup_entry_standalone_oauth_refreshes_token`): constructs a config entry
with `auth_mode=standalone_oauth`, valid client creds + refresh token; mocks the
SmartThings token endpoint; calls `async_setup_entry`; asserts `hub.token == "fresh-access-token"`.

Test 2 (`test_setup_entry_standalone_oauth_with_samsung_iot`): same + `samsung_iot_refresh_token`
in entry data; mocks Samsung IoT refresh endpoint; asserts `hub._samsung_iot_headers` is set
with the new IoT access token.

## Risks / follow-ups
- Samsung IoT token rotation on the update listener is not yet tested (follows from
  this PR's pattern but was not in the acceptance criteria).
- `async_step_reauth_standalone_oauth_link` calls `self._get_reauth_entry()` which
  requires the HA runtime — covered by the routing unit test, end-to-end reauth
  flow exercised in integration would need a live HA test harness.