### PR TITLE
SCRUM-84: Samsung IoT token in-session refresh

### DIFF
--- a/custom_components/samsung_familyhub_fridge/__init__.py
+++ b/custom_components/samsung_familyhub_fridge/__init__.py
@@ -152,7 +152,12 @@ async def _build_oauth_hub(
             iot_creds = await hass.async_add_executor_job(
                 refresh_samsung_iot_token, iot_refresh, iot_server
             )
-            hub.set_samsung_iot_token(iot_creds.access_token)
+            hub.set_samsung_iot_token(
+                iot_creds.access_token,
+                refresh_token=iot_creds.refresh_token,
+                auth_server=iot_server,
+                entry=entry,
+            )
             # Persist the new refresh token for next startup
             if iot_creds.refresh_token != iot_refresh:
                 new_data = {
@@ -216,7 +221,12 @@ async def _build_standalone_oauth_hub(
             iot_creds = await hass.async_add_executor_job(
                 refresh_samsung_iot_token, iot_refresh, iot_server
             )
-            hub.set_samsung_iot_token(iot_creds.access_token)
+            hub.set_samsung_iot_token(
+                iot_creds.access_token,
+                refresh_token=iot_creds.refresh_token,
+                auth_server=iot_server,
+                entry=entry,
+            )
             if iot_creds.refresh_token != iot_refresh:
                 new_data = {
                     **entry.data,

--- a/custom_components/samsung_familyhub_fridge/api.py
+++ b/custom_components/samsung_familyhub_fridge/api.py
@@ -123,18 +123,71 @@ class FamilyHub:
         # Only set in OAuth mode; PAT tokens already carry Samsung ID.
         self._samsung_iot_token: str | None = None
         self._samsung_iot_headers: dict | None = None
+        self._samsung_iot_refresh_token: str | None = None
+        self._samsung_iot_auth_server: str = "https://us-auth2.samsungosp.com"
+        self._entry = None
 
-    def set_samsung_iot_token(self, token: str) -> None:
+    def set_samsung_iot_token(
+        self,
+        token: str,
+        refresh_token: str | None = None,
+        auth_server: str | None = None,
+        entry=None,
+    ) -> None:
         """Set a Samsung IoT token for client.smartthings.com image downloads.
 
         This token carries Samsung Account identity and is needed because
         the udo/file_links endpoint rejects standard SmartThings OAuth tokens.
+        Optionally store a refresh_token, auth_server, and config entry so
+        download_images() can silently refresh the token on auth failures.
         """
         self._samsung_iot_token = token
         self._samsung_iot_headers = {
             "Authorization": f"Bearer {token}",
             "Accept": "application/vnd.smartthings+json;v=1",
         }
+        if refresh_token is not None:
+            self._samsung_iot_refresh_token = refresh_token
+        if auth_server is not None:
+            self._samsung_iot_auth_server = auth_server
+        if entry is not None:
+            self._entry = entry
+
+    def _is_no_samsung_id_error(self, response: requests.Response) -> bool:
+        """Return True if response body contains 'No samsung id' (400 auth error)."""
+        try:
+            return "No samsung id" in response.text
+        except Exception:
+            return False
+
+    def _do_samsung_iot_refresh(self) -> None:
+        """Refresh the Samsung IoT token in-place and persist the new refresh token."""
+        from .auth import refresh_samsung_iot_token
+
+        try:
+            iot_creds = refresh_samsung_iot_token(
+                self._samsung_iot_refresh_token,
+                self._samsung_iot_auth_server,
+            )
+        except Exception as err:
+            raise AuthenticationError(
+                f"Samsung IoT token refresh failed: {err}"
+            ) from err
+
+        self.set_samsung_iot_token(
+            iot_creds.access_token,
+            refresh_token=iot_creds.refresh_token,
+            auth_server=self._samsung_iot_auth_server,
+            entry=self._entry,
+        )
+
+        if self._entry is not None:
+            from .const import CONF_SAMSUNG_IOT_REFRESH_TOKEN
+            new_data = {
+                **self._entry.data,
+                CONF_SAMSUNG_IOT_REFRESH_TOKEN: iot_creds.refresh_token,
+            }
+            self._hass.config_entries.async_update_entry(self._entry, data=new_data)
 
     def attach_oauth_session(
         self, session: "config_entry_oauth2_flow.OAuth2Session"
@@ -238,6 +291,26 @@ class FamilyHub:
                     headers=dl_headers,
                     timeout=DEFAULT_TIMEOUT,
                 )
+                # Samsung IoT in-session refresh: when using IoT headers and the
+                # server returns 401/403 or a 400 'No samsung id' error, attempt
+                # a silent token refresh and retry once before surfacing as
+                # ConfigEntryAuthFailed.
+                if dl_headers is self._samsung_iot_headers:
+                    auth_fail = r.status_code in (401, 403) or (
+                        r.status_code == 400 and self._is_no_samsung_id_error(r)
+                    )
+                    if auth_fail:
+                        if not self._samsung_iot_refresh_token:
+                            raise AuthenticationError(
+                                f"Samsung IoT authentication failed "
+                                f"(HTTP {r.status_code}) — no refresh token available."
+                            )
+                        self._do_samsung_iot_refresh()
+                        r = requests.get(
+                            url,
+                            headers=self._samsung_iot_headers,
+                            timeout=DEFAULT_TIMEOUT,
+                        )
                 self._check_response(r)
                 content_type = r.headers.get("content-type", "")
                 _LOGGER.debug(

--- a/tests/test_iot_refresh.py
+++ b/tests/test_iot_refresh.py
@@ -1,0 +1,177 @@
+"""Integration tests for Samsung IoT token in-session refresh (SCRUM-84).
+
+Verifies that download_images() silently refreshes an expired Samsung IoT
+token and retries the download rather than surfacing ConfigEntryAuthFailed.
+"""
+from __future__ import annotations
+
+import pytest
+from unittest.mock import MagicMock
+
+from tests.conftest import _HomeAssistant, _ConfigEntry
+from custom_components.samsung_familyhub_fridge.api import (
+    AuthenticationError,
+    FamilyHub,
+)
+from custom_components.samsung_familyhub_fridge.const import (
+    CID,
+    CONF_SAMSUNG_IOT_REFRESH_TOKEN,
+)
+
+# Minimal device status that produces one file_id
+DEVICE_STATUS = {
+    "samsungce.viewInside": {
+        "contents": {"value": [{"fileId": "file-abc123"}]}
+    }
+}
+DEVICE_ID = "device-123"
+FILE_ID = "file-abc123"
+SAMSUNG_IOT_REFRESH_URL = "https://us-auth2.samsungosp.com/auth/oauth2/token"
+JPEG_BYTES = b"\xff\xd8\xff\xe0" + b"\x00" * 100
+
+
+def _file_link_url(file_id: str = FILE_ID, device_id: str = DEVICE_ID) -> str:
+    return (
+        f"https://client.smartthings.com/udo/file_links/{file_id}"
+        f"?cid={CID}&di={device_id}"
+    )
+
+
+def _make_hass():
+    hass = _HomeAssistant()
+    hass.config_entries = MagicMock()
+    return hass
+
+
+# ---------------------------------------------------------------------------
+# Test 1: hub has IoT token + refresh token — 401 → refresh → retry → success
+# ---------------------------------------------------------------------------
+
+
+class TestIoTRefreshOnAuthFailure:
+    """401 during download triggers silent refresh and successful retry."""
+
+    def test_download_retries_after_401_and_persists_new_refresh_token(
+        self, requests_mock
+    ):
+        """401 on first IoT download → refresh → retry returns image → True."""
+        hass = _make_hass()
+        entry = _ConfigEntry(
+            entry_id="iot-refresh-test",
+            data={
+                CONF_SAMSUNG_IOT_REFRESH_TOKEN: "old-iot-refresh-token",
+                "samsung_iot_auth_server": "https://us-auth2.samsungosp.com",
+            },
+        )
+        hub = FamilyHub(hass, token="st-token", device_id=DEVICE_ID)
+        hub._current_device_status = DEVICE_STATUS
+        hub.set_samsung_iot_token(
+            "old-iot-access-token",
+            refresh_token="old-iot-refresh-token",
+            auth_server="https://us-auth2.samsungosp.com",
+            entry=entry,
+        )
+
+        url = _file_link_url()
+        # First call: 401 (token expired); second call: 200 + JPEG (after refresh)
+        requests_mock.get(url, [
+            {"status_code": 401, "json": {"error": "Unauthorized"}},
+            {
+                "status_code": 200,
+                "content": JPEG_BYTES,
+                "headers": {"content-type": "image/jpeg"},
+            },
+        ])
+        # Samsung IoT refresh endpoint returns new tokens
+        requests_mock.post(
+            SAMSUNG_IOT_REFRESH_URL,
+            json={
+                "access_token": "new-iot-access-token",
+                "refresh_token": "new-iot-refresh-token",
+            },
+        )
+
+        result = hub.download_images()
+
+        assert result is True, "download_images() must return True on successful retry"
+        assert hub._samsung_iot_refresh_token == "new-iot-refresh-token", (
+            "In-memory refresh token must be updated after successful refresh"
+        )
+        # Config entry must be persisted with the new refresh token
+        hass.config_entries.async_update_entry.assert_called_once()
+        _, kwargs = hass.config_entries.async_update_entry.call_args
+        assert kwargs["data"][CONF_SAMSUNG_IOT_REFRESH_TOKEN] == "new-iot-refresh-token", (
+            "Config entry data must contain the rotated samsung_iot_refresh_token"
+        )
+
+    def test_download_retries_after_400_no_samsung_id(self, requests_mock):
+        """400 with 'No samsung id' triggers refresh and retry."""
+        hass = _make_hass()
+        entry = _ConfigEntry(
+            entry_id="iot-refresh-400",
+            data={CONF_SAMSUNG_IOT_REFRESH_TOKEN: "old-refresh"},
+        )
+        hub = FamilyHub(hass, token="st-token", device_id=DEVICE_ID)
+        hub._current_device_status = DEVICE_STATUS
+        hub.set_samsung_iot_token(
+            "old-iot-token",
+            refresh_token="old-refresh",
+            auth_server="https://us-auth2.samsungosp.com",
+            entry=entry,
+        )
+
+        url = _file_link_url()
+        requests_mock.get(url, [
+            {
+                "status_code": 400,
+                "json": {
+                    "error": "BadRequestError",
+                    "message": "No samsung id available",
+                },
+            },
+            {
+                "status_code": 200,
+                "content": JPEG_BYTES,
+                "headers": {"content-type": "image/jpeg"},
+            },
+        ])
+        requests_mock.post(
+            SAMSUNG_IOT_REFRESH_URL,
+            json={
+                "access_token": "new-iot-access",
+                "refresh_token": "new-refresh",
+            },
+        )
+
+        result = hub.download_images()
+
+        assert result is True
+        assert hub._samsung_iot_refresh_token == "new-refresh"
+
+
+# ---------------------------------------------------------------------------
+# Test 2: hub has no _samsung_iot_refresh_token — 401 must raise immediately
+# ---------------------------------------------------------------------------
+
+
+class TestIoTAuthFailureWithoutRefreshToken:
+    """No refresh token: 401 raises AuthenticationError immediately, no retry."""
+
+    def test_401_raises_auth_error_without_retry(self, requests_mock):
+        """Without a refresh token, 401 raises AuthenticationError after one request."""
+        hass = _make_hass()
+        hub = FamilyHub(hass, token="st-token", device_id=DEVICE_ID)
+        hub._current_device_status = DEVICE_STATUS
+        # Set IoT token but NO refresh_token
+        hub.set_samsung_iot_token("iot-access-only")
+
+        url = _file_link_url()
+        requests_mock.get(url, status_code=401)
+
+        with pytest.raises(AuthenticationError):
+            hub.download_images()
+
+        # Exactly one HTTP GET made — no retry attempted
+        assert requests_mock.call_count == 1, (
+            "Must not retry when no refresh token is available"
+        )


### PR DESCRIPTION
[Calion Chart-Keeper] — sme-scrum-84

## Task
SCRUM-84 — Task D: Samsung IoT token in-session refresh

## Summary
`FamilyHub.download_images()` now silently refreshes an expired Samsung IoT token on 401/403 or 400 'No samsung id' responses and retries the download once, rather than immediately surfacing `ConfigEntryAuthFailed` and forcing a full reauthentication. Without a refresh token the original `AuthenticationError` propagates immediately (PAT mode behaviour unchanged).

## What changed
- **api.py** — `FamilyHub.__init__`: added `_samsung_iot_refresh_token`, `_samsung_iot_auth_server`, `_entry` fields
- **api.py** — `set_samsung_iot_token()`: extended with optional `refresh_token`, `auth_server`, `entry` params
- **api.py** — new `_is_no_samsung_id_error()` helper: detects 400 'No samsung id' auth failures
- **api.py** — new `_do_samsung_iot_refresh()`: calls `refresh_samsung_iot_token()`, updates in-memory headers, persists rotated refresh token to config entry
- **api.py** — `download_images()`: wraps per-image block with IoT auth-failure detection + single retry
- **__init__.py** — both `_build_oauth_hub` and `_build_standalone_oauth_hub` now pass `refresh_token`, `auth_server`, `entry` to `hub.set_samsung_iot_token()`
- **tests/test_iot_refresh.py** — 3 integration tests covering the two acceptance scenarios

## Unit testing
```
python3 -m pytest tests/ --ignore=tests/test_integration.py -q
84 passed in 0.57s
```

## Integration testing (required)

### Acceptance test 1 — refresh + retry → True, entry persisted
```
python3 -m pytest tests/ -k 'iot_refresh' -v

tests/test_iot_refresh.py::TestIoTRefreshOnAuthFailure::test_download_retries_after_401_and_persists_new_refresh_token PASSED
tests/test_iot_refresh.py::TestIoTRefreshOnAuthFailure::test_download_retries_after_400_no_samsung_id PASSED
tests/test_iot_refresh.py::TestIoTAuthFailureWithoutRefreshToken::test_401_raises_auth_error_without_retry PASSED

3 passed, 97 deselected in 0.18s
```

- Hub has Samsung IoT token + refresh token; first download returns 401; Samsung IoT refresh endpoint returns new tokens; second download returns 200 + JPEG. `download_images()` returns `True` and `config_entries.async_update_entry` is called with the new `samsung_iot_refresh_token`.
- Hub has no `_samsung_iot_refresh_token`; download returns 401; `AuthenticationError` raised after exactly one HTTP request (no retry).

## Risks / follow-ups
- `_do_samsung_iot_refresh` is called synchronously inside the executor thread. `config_entries.async_update_entry` is a sync method (no IO) so this is safe, consistent with how `__init__.py` already calls it from async context.
- Only one retry is attempted; if the refreshed token is also invalid, `_check_response` raises `AuthenticationError` → `ConfigEntryAuthFailed` as before.